### PR TITLE
Jmprieur/sign in and call graph

### DIFF
--- a/Controllers/AccountController.cs
+++ b/Controllers/AccountController.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authentication;
+﻿using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Mvc;
@@ -17,7 +13,7 @@ namespace WebApp_OpenIDConnect_DotNet.Controllers
         {
             var redirectUrl = Url.Action(nameof(HomeController.Index), "Home");
             return Challenge(
-                new AuthenticationProperties { RedirectUri = redirectUrl, IsPersistent=true },
+                new AuthenticationProperties { RedirectUri = redirectUrl, IsPersistent = true },
                 OpenIdConnectDefaults.AuthenticationScheme);
         }
 

--- a/Controllers/AccountController.cs
+++ b/Controllers/AccountController.cs
@@ -17,7 +17,7 @@ namespace WebApp_OpenIDConnect_DotNet.Controllers
         {
             var redirectUrl = Url.Action(nameof(HomeController.Index), "Home");
             return Challenge(
-                new AuthenticationProperties { RedirectUri = redirectUrl },
+                new AuthenticationProperties { RedirectUri = redirectUrl, IsPersistent=true },
                 OpenIdConnectDefaults.AuthenticationScheme);
         }
 

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -49,7 +49,7 @@ namespace WebApp_OpenIDConnect_DotNet.Controllers
                 ViewData["Me"] = me;
                 return View();
             }
-            catch(MsalException)
+            catch (MsalException)
             {
                 var redirectUrl = Url.Action(nameof(HomeController.Contact), "Home");
                 return Challenge(

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -40,18 +40,16 @@ namespace WebApp_OpenIDConnect_DotNet.Controllers
         public async Task<IActionResult> Contact()
         {
             string[] scopes = new string[] { "user.read" };
-
-            var claims = User.Claims.ToArray();
             try
 
             {
-                string accessToken = await tokenAcquisition.GetAccessTokenOnBehalfOfUser(User, scopes);
+                string accessToken = await tokenAcquisition.GetAccessTokenOnBehalfOfUser(HttpContext, User, scopes);
                 dynamic me = await CallGraphApiOnBehalfOfUser(accessToken);
 
                 ViewData["Me"] = me;
                 return View();
             }
-            catch(MsalException ex)
+            catch(MsalException)
             {
                 var redirectUrl = Url.Action(nameof(HomeController.Contact), "Home");
                 return Challenge(

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -1,10 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
+using TodoListService.Extensions;
 using WebApp_OpenIDConnect_DotNet.Models;
 
 namespace WebApp_OpenIDConnect_DotNet.Controllers
@@ -12,6 +16,12 @@ namespace WebApp_OpenIDConnect_DotNet.Controllers
     [Authorize]
     public class HomeController : Controller
     {
+        public HomeController(ITokenAcquisition tokenAcquisition)
+        {
+            this.tokenAcquisition = tokenAcquisition;
+        }
+        ITokenAcquisition tokenAcquisition;
+
         public IActionResult Index()
         {
             return View();
@@ -24,11 +34,36 @@ namespace WebApp_OpenIDConnect_DotNet.Controllers
             return View();
         }
 
-        public IActionResult Contact()
+        public async Task<IActionResult> Contact()
         {
-            ViewData["Message"] = "Your contact page.";
+            string[] scopes = new string[] { "user.read" };
 
+            var claims = User.Claims.ToArray();
+            string accessToken = await tokenAcquisition.GetAccessTokenOnBehalfOfUser(User, scopes);
+            dynamic me = await CallGraphApiOnBehalfOfUser(accessToken);
+
+            ViewData["Me"] = me;
             return View();
+        }
+
+        private static async Task<dynamic> CallGraphApiOnBehalfOfUser(string accessToken)
+        {
+            //
+            // Call the Graph API and retrieve the user's profile.
+            //
+            HttpClient client = new HttpClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            HttpResponseMessage response = await client.GetAsync("https://graph.microsoft.com/Beta/me");
+            string content = await response.Content.ReadAsStringAsync();
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                dynamic me = JsonConvert.DeserializeObject(content);
+                return me;
+            }
+            else
+            {
+                throw new Exception(content);
+            }
         }
 
         [AllowAnonymous]

--- a/Extensions/AuthPropertiesTokenCacheHelper.cs
+++ b/Extensions/AuthPropertiesTokenCacheHelper.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Identity.Client;
+
+namespace TodoListService.Extensions
+{
+    public class AuthPropertiesTokenCacheHelper
+    {
+        private const string TokenCacheKey = ".UserTokenCache";
+
+        private HttpContext _httpContext;
+        private ClaimsPrincipal _principal;
+        private AuthenticationProperties _authProperties;
+        private string _signInScheme;
+        public TokenCache TokenCache { get; private set; }
+
+        private AuthPropertiesTokenCacheHelper(AuthenticationProperties authProperties) : base()
+        {
+            _authProperties = authProperties;
+            TokenCache = new TokenCache();
+            TokenCache.SetBeforeAccess(BeforeAccessNotificationWithProperties);
+            TokenCache.SetAfterAccess(AfterAccessNotificationWithProperties);
+            TokenCache.SetBeforeWrite(BeforeWriteNotification);
+        }
+
+        private AuthPropertiesTokenCacheHelper(HttpContext httpContext, string signInScheme) : base()
+        {
+            _httpContext = httpContext;
+            _signInScheme = signInScheme;
+            TokenCache = new TokenCache();
+            TokenCache.SetBeforeAccess(BeforeAccessNotificationWithContext);
+            TokenCache.SetAfterAccess(AfterAccessNotificationWithContext);
+            TokenCache.SetBeforeWrite(BeforeWriteNotification);
+        }
+
+        public static TokenCache ForCodeRedemption(AuthenticationProperties authProperties)
+        {
+            return new AuthPropertiesTokenCacheHelper(authProperties).TokenCache;
+        }
+
+        public static TokenCache ForApiCalls(HttpContext httpContext,
+            string signInScheme = CookieAuthenticationDefaults.AuthenticationScheme)
+        {
+            return new AuthPropertiesTokenCacheHelper(httpContext, signInScheme).TokenCache;
+        }
+
+        private void BeforeAccessNotificationWithProperties(TokenCacheNotificationArgs args)
+        {
+            string cachedTokensText;
+            if (_authProperties.Items.TryGetValue(TokenCacheKey, out cachedTokensText))
+            {
+                var cachedTokens = Convert.FromBase64String(cachedTokensText);
+                TokenCache.Deserialize(cachedTokens);
+            }
+        }
+
+        private void BeforeAccessNotificationWithContext(TokenCacheNotificationArgs args)
+        {
+            // Retrieve the auth session with the cached tokens
+            var result = _httpContext.AuthenticateAsync(_signInScheme).Result;
+            _authProperties = result.Ticket.Properties;
+            _principal = result.Ticket.Principal;
+
+            BeforeAccessNotificationWithProperties(args);
+        }
+
+        private void AfterAccessNotificationWithProperties(TokenCacheNotificationArgs args)
+        {
+            // if state changed
+            if (TokenCache.HasStateChanged)
+            {
+                var cachedTokens = TokenCache.Serialize();
+                var cachedTokensText = Convert.ToBase64String(cachedTokens);
+                _authProperties.Items[TokenCacheKey] = cachedTokensText;
+            }
+        }
+
+        private void AfterAccessNotificationWithContext(TokenCacheNotificationArgs args)
+        {
+            // if state changed
+            if (TokenCache.HasStateChanged)
+            {
+                AfterAccessNotificationWithProperties(args);
+
+                var cachedTokens = TokenCache.Serialize();
+                var cachedTokensText = Convert.ToBase64String(cachedTokens);
+                _authProperties.Items[TokenCacheKey] = cachedTokensText;
+                _httpContext.SignInAsync(_signInScheme, _principal, _authProperties).Wait();
+            }
+        }
+
+        private void BeforeWriteNotification(TokenCacheNotificationArgs args)
+        {
+            // if you want to ensure that no concurrent write take place, use this notification to place a lock on the entry
+        }
+    }
+}

--- a/Extensions/AuthPropertiesTokenCacheHelper.cs
+++ b/Extensions/AuthPropertiesTokenCacheHelper.cs
@@ -10,12 +10,10 @@ namespace TodoListService.Extensions
     public class AuthPropertiesTokenCacheHelper
     {
         private const string TokenCacheKey = ".UserTokenCache";
-
         private HttpContext _httpContext;
         private ClaimsPrincipal _principal;
         private AuthenticationProperties _authProperties;
         private string _signInScheme;
-        public TokenCache TokenCache { get; private set; }
 
         private AuthPropertiesTokenCacheHelper(AuthenticationProperties authProperties) : base()
         {
@@ -36,6 +34,8 @@ namespace TodoListService.Extensions
             TokenCache.SetBeforeWrite(BeforeWriteNotification);
         }
 
+        public TokenCache TokenCache { get; private set; }
+
         public static TokenCache ForCodeRedemption(AuthenticationProperties authProperties)
         {
             return new AuthPropertiesTokenCacheHelper(authProperties).TokenCache;
@@ -51,10 +51,7 @@ namespace TodoListService.Extensions
         {
             string cachedTokensText;
             if (_authProperties.Items.TryGetValue(TokenCacheKey, out cachedTokensText))
-            {
-                var cachedTokens = Convert.FromBase64String(cachedTokensText);
-                TokenCache.Deserialize(cachedTokens);
-            }
+                TokenCache.Deserialize(Convert.FromBase64String(cachedTokensText));
         }
 
         private void BeforeAccessNotificationWithContext(TokenCacheNotificationArgs args)
@@ -73,8 +70,7 @@ namespace TodoListService.Extensions
             if (TokenCache.HasStateChanged)
             {
                 var cachedTokens = TokenCache.Serialize();
-                var cachedTokensText = Convert.ToBase64String(cachedTokens);
-                _authProperties.Items[TokenCacheKey] = cachedTokensText;
+                _authProperties.Items[TokenCacheKey] = Convert.ToBase64String(cachedTokens);
             }
         }
 
@@ -86,8 +82,7 @@ namespace TodoListService.Extensions
                 AfterAccessNotificationWithProperties(args);
 
                 var cachedTokens = TokenCache.Serialize();
-                var cachedTokensText = Convert.ToBase64String(cachedTokens);
-                _authProperties.Items[TokenCacheKey] = cachedTokensText;
+                _authProperties.Items[TokenCacheKey] = Convert.ToBase64String(cachedTokens);
                 _httpContext.SignInAsync(_signInScheme, _principal, _authProperties).Wait();
             }
         }

--- a/Extensions/AzureAdAuthenticationBuilderExtensions.cs
+++ b/Extensions/AzureAdAuthenticationBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
 using System;
 using System.Threading.Tasks;
 using TodoListService.Extensions;
@@ -39,10 +40,10 @@ namespace Microsoft.AspNetCore.Authentication
                 options.RequireHttpsMetadata = false;
                 options.TokenValidationParameters.ValidateIssuer = false;     // accept several tenants
                 options.Events = new OpenIdConnectEvents();
-                options.Events.OnTokenValidated = OnTokenValidated;
+                options.Events.OnAuthorizationCodeReceived = OnAuthorizationCodeReceived;
                 options.Scope.Add("user.read");
 
-                options.ResponseType = "id_token token";
+                options.ResponseType = "code id_token";
             }
 
             public void Configure(OpenIdConnectOptions options)
@@ -50,9 +51,10 @@ namespace Microsoft.AspNetCore.Authentication
                 Configure(Options.DefaultName, options);
             }
 
-            private async Task OnTokenValidated(TokenValidatedContext context)
+            private async Task OnAuthorizationCodeReceived(AuthorizationCodeReceivedContext context)
             {
-                _tokenAcquisition.AddAccountToCacheFromJwt(context.SecurityToken);
+                string[] scopes = new string[] { "user.read" };
+                await _tokenAcquisition.AddAccountToCacheFromAuthorizationCode(context, scopes);
             }
         }
     }

--- a/Extensions/AzureAdAuthenticationBuilderExtensions.cs
+++ b/Extensions/AzureAdAuthenticationBuilderExtensions.cs
@@ -1,13 +1,14 @@
-﻿using System;
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using System;
+using System.Threading.Tasks;
+using TodoListService.Extensions;
 
 namespace Microsoft.AspNetCore.Authentication
 {
     public static class AzureAdAuthenticationBuilderExtensions
-    {        
+    {
         public static AuthenticationBuilder AddAzureAd(this AuthenticationBuilder builder)
             => builder.AddAzureAd(_ => { });
 
@@ -19,27 +20,39 @@ namespace Microsoft.AspNetCore.Authentication
             return builder;
         }
 
-        private class ConfigureAzureOptions: IConfigureNamedOptions<OpenIdConnectOptions>
+        private class ConfigureAzureOptions : IConfigureNamedOptions<OpenIdConnectOptions>
         {
             private readonly AzureAdOptions _azureOptions;
+            private readonly ITokenAcquisition _tokenAcquisition;
 
-            public ConfigureAzureOptions(IOptions<AzureAdOptions> azureOptions)
+            public ConfigureAzureOptions(IOptions<AzureAdOptions> azureOptions, ITokenAcquisition tokenAcquisition)
             {
                 _azureOptions = azureOptions.Value;
+                _tokenAcquisition = tokenAcquisition;
             }
 
             public void Configure(string name, OpenIdConnectOptions options)
             {
                 options.ClientId = _azureOptions.ClientId;
-                options.Authority = $"{_azureOptions.Instance}common/v2.0";   // V2 specific
+                options.Authority = $"{_azureOptions.Instance}{_azureOptions.TenantId}/v2.0";   // V2 specific
                 options.UseTokenLifetime = true;
                 options.RequireHttpsMetadata = false;
                 options.TokenValidationParameters.ValidateIssuer = false;     // accept several tenants
+                options.Events = new OpenIdConnectEvents();
+                options.Events.OnTokenValidated = OnTokenValidated;
+                options.Scope.Add("user.read");
+
+                options.ResponseType = "id_token token";
             }
 
             public void Configure(OpenIdConnectOptions options)
             {
                 Configure(Options.DefaultName, options);
+            }
+
+            private async Task OnTokenValidated(TokenValidatedContext context)
+            {
+                _tokenAcquisition.AddAccountToCacheFromJwt(context.SecurityToken);
             }
         }
     }

--- a/Extensions/AzureAdAuthenticationBuilderExtensions.cs
+++ b/Extensions/AzureAdAuthenticationBuilderExtensions.cs
@@ -1,9 +1,8 @@
-﻿using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Microsoft.Identity.Client;
-using System;
-using System.Threading.Tasks;
 using TodoListService.Extensions;
 
 namespace Microsoft.AspNetCore.Authentication
@@ -53,8 +52,7 @@ namespace Microsoft.AspNetCore.Authentication
 
             private async Task OnAuthorizationCodeReceived(AuthorizationCodeReceivedContext context)
             {
-                string[] scopes = new string[] { "user.read" };
-                await _tokenAcquisition.AddAccountToCacheFromAuthorizationCode(context, scopes);
+                await _tokenAcquisition.AddAccountToCacheFromAuthorizationCode(context, new string[] { "user.read" });
             }
         }
     }

--- a/Extensions/AzureAdOptions.cs
+++ b/Extensions/AzureAdOptions.cs
@@ -13,5 +13,7 @@
         public string TenantId { get; set; }
 
         public string CallbackPath { get; set; }
+
+        public string RedirectUri { get; set; }
     }
 }

--- a/Extensions/AzureAdOptions.cs
+++ b/Extensions/AzureAdOptions.cs
@@ -13,7 +13,5 @@
         public string TenantId { get; set; }
 
         public string CallbackPath { get; set; }
-
-        public string RedirectUri { get; set; }
     }
 }

--- a/Extensions/ITokenAcquisition.cs
+++ b/Extensions/ITokenAcquisition.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Identity.Client;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Identity.Client;
 
 namespace TodoListService.Extensions
 {
@@ -12,7 +12,7 @@ namespace TodoListService.Extensions
     {
         /// <summary>
         /// Add, to the MSAL.NET cache, the account of the user for which a bearer token was received when the Web API was called.
-        /// An On-behalf-of token is added to the cache, so that it can then be used to acquire another token on On-behalf-of the 
+        /// An On-behalf-of token is added to the cache, so that it can then be used to acquire another token on-behalf-of the 
         /// same user in order to call to downstream APIs.
         /// </summary>
         /// <param name="userAccessToken">Access token used to call this Web API</param>
@@ -38,6 +38,31 @@ namespace TodoListService.Extensions
         /// </example>
         void AddAccountToCacheFromJwt(JwtSecurityToken jwtToken, IEnumerable<string> scopes);
 
+        /// <summary>
+        /// Add, to the MSAL.NET cache, the account of the user for which an authorization code was received when the Web API was called.
+        /// An On-behalf-of token contained in the <see cref="AuthorizationCodeReceivedContext"/> is added to the cache, so that it can then be used to acquire another token on-behalf-of the 
+        /// same user in order to call to downstream APIs.
+        /// </summary>
+        /// <param name="context">The context used when an 'AuthorizationCode' is received over the OpenIdConnect protocol.</param>
+        /// <example>
+        /// From the configuration of the Authentication of the ASP.NET Core Web API: 
+        /// <code>OpenIdConnectOptions options;</code>
+        /// 
+        /// Subscribe to the authorization code recieved event:
+        /// <code>
+        ///  options.Events = new OpenIdConnectEvents();
+        ///  options.Events.OnAuthorizationCodeReceived = OnAuthorizationCodeReceived;
+        /// }
+        /// </code>
+        /// 
+        /// And then in the OnAuthorizationCodeRecieved method, call <see cref="AddAccountToCacheFromAuthorizationCode"/>:
+        /// <code>
+        /// private async Task OnAuthorizationCodeReceived(AuthorizationCodeReceivedContext context)
+        /// {
+        ///    await _tokenAcquisition.AddAccountToCacheFromAuthorizationCode(context, new string[] { "user.read" });
+        /// }
+        /// </code>
+        /// </example>
         Task AddAccountToCacheFromAuthorizationCode(AuthorizationCodeReceivedContext context, IEnumerable<string> scopes);
 
         /// <summary>

--- a/Extensions/ITokenAcquisition.cs
+++ b/Extensions/ITokenAcquisition.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Identity.Client;
+﻿using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Identity.Client;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -33,9 +36,9 @@ namespace TodoListService.Extensions
         /// }
         /// </code>
         /// </example>
-        void AddAccountToCacheFromJwt(JwtSecurityToken jwtToken);
+        void AddAccountToCacheFromJwt(JwtSecurityToken jwtToken, IEnumerable<string> scopes);
 
-        void AddAccountToCacheFromAuthorizationCode(string code);
+        Task AddAccountToCacheFromAuthorizationCode(AuthorizationCodeReceivedContext context, IEnumerable<string> scopes);
 
         /// <summary>
         /// Gets an access token for a downstream API on behalf of the user account which claims are provided in the 
@@ -44,7 +47,7 @@ namespace TodoListService.Extensions
         /// <param name="user">User account described by its claims</param>
         /// <param name="scopes">Scopes to request for the downstream API to call</param>
         /// <returns>An access token to call on behalf of the user, the downstream API characterized by its scopes</returns>
-        Task<string> GetAccessTokenOnBehalfOfUser(ClaimsPrincipal user, string[] scopes);
+        Task<string> GetAccessTokenOnBehalfOfUser(HttpContext context, ClaimsPrincipal user, string[] scopes);
 
         /// <summary>
         /// Gets an access token for a downstream API on behalf of the user of a given account ID

--- a/Extensions/ITokenAcquisition.cs
+++ b/Extensions/ITokenAcquisition.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.Identity.Client;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace TodoListService.Extensions
+{
+    public interface ITokenAcquisition
+    {
+        /// <summary>
+        /// Add, to the MSAL.NET cache, the account of the user for which a bearer token was received when the Web API was called.
+        /// An On-behalf-of token is added to the cache, so that it can then be used to acquire another token on On-behalf-of the 
+        /// same user in order to call to downstream APIs.
+        /// </summary>
+        /// <param name="userAccessToken">Access token used to call this Web API</param>
+        /// <example>
+        /// From the configuration of the Authentication of the ASP.NET Core Web API: 
+        /// <code>JwtBearerOptions option;</code>
+        /// 
+        /// Subscribe to the token validated event:
+        /// <code>
+        /// options.Events = new JwtBearerEvents();
+        /// options.Events.OnTokenValidated = OnTokenValidated;
+        /// }
+        /// </code>
+        /// 
+        /// And then in the OnTokenValidated method, call <see cref="AddAccountToCache(JwtSecurityToken)"/>:
+        /// <code>
+        /// private async Task OnTokenValidated(TokenValidatedContext context)
+        /// {
+        ///  JwtSecurityToken accessToken = context.SecurityToken as JwtSecurityToken;
+        ///  _tokenAcquisition.AddAccountToCache(accessToken);
+        /// }
+        /// </code>
+        /// </example>
+        void AddAccountToCacheFromJwt(JwtSecurityToken jwtToken);
+
+        void AddAccountToCacheFromAuthorizationCode(string code);
+
+        /// <summary>
+        /// Gets an access token for a downstream API on behalf of the user account which claims are provided in the 
+        /// <paramref name="user"/> parameter
+        /// </summary>
+        /// <param name="user">User account described by its claims</param>
+        /// <param name="scopes">Scopes to request for the downstream API to call</param>
+        /// <returns>An access token to call on behalf of the user, the downstream API characterized by its scopes</returns>
+        Task<string> GetAccessTokenOnBehalfOfUser(ClaimsPrincipal user, string[] scopes);
+
+        /// <summary>
+        /// Gets an access token for a downstream API on behalf of the user of a given account ID
+        /// </summary>
+        /// <param name="accountIdentifier">User account identifier for which to acquire a token. 
+        /// See <see cref="Microsoft.Identity.Client.AccountId.Identifier"/> for a description on how
+        /// to get the account identifier</param>
+        /// <param name="scopes">Scopes for the downstream API to call</param>
+        Task<string> GetAccessTokenOnBehalfOfUser(string userId, string[] scopes);
+
+        /// <summary>
+        /// Access to the MSAL.NET confidential client application (for advanced scenarios)
+        /// </summary>
+        ConfidentialClientApplication Application { get; }
+    }
+}

--- a/Extensions/TokenAcquisition.cs
+++ b/Extensions/TokenAcquisition.cs
@@ -1,0 +1,163 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace TodoListService.Extensions
+{
+    public class TokenAcquisition : ITokenAcquisition
+    {
+        /// <summary>
+        /// Constructor of the TokenAcquisition service. This requires the Azure AD Options to 
+        /// configure the confidential client application
+        /// </summary>
+        /// <param name="options">Options to configure the application</param>
+        public TokenAcquisition(IOptions<AzureAdOptions> options)
+        {
+            GetOrCreateApplication(options.Value);
+        }
+
+        /// <summary>
+        /// The goal of this method is, when a user is authenticated, to add the user's account in the MSAL.NET cache
+        /// so that this token can then be used to acquire a token on On-behalf-of the user befor call to downstream APIs.
+        /// </summary>
+        /// <param name="userAccessToken">Access token used to call this Web API</param>
+        /// <example>
+        /// From configuration of the Authentication of the ASP.NET Core Web API 
+        /// <code>JwtBearerOptions option;</code>
+        /// 
+        /// Subscribe to the token validated event
+        /// <code>
+        /// options.Events = new JwtBearerEvents();
+        /// options.Events.OnTokenValidated = OnTokenValidated;
+        /// }
+        /// </code>
+        /// 
+        /// And then in the OnTokenValidated method:
+        /// <code>
+        /// private async Task OnTokenValidated(TokenValidatedContext context)
+        /// {
+        ///  JwtSecurityToken accessToken = context.SecurityToken as JwtSecurityToken;
+        ///  _tokenAcquisition.AddAccountToCache(accessToken);
+        /// }
+        /// </code>
+        /// </example>
+        public void AddAccountToCacheFromJwt(JwtSecurityToken jwtToken)
+        {
+            string userAccessTokenForThisApi = jwtToken.RawData;
+            string[] scopes = new string[] { "user.read" };
+            try
+            {
+                UserAssertion userAssertion = new UserAssertion(userAccessTokenForThisApi, "urn:ietf:params:oauth:grant-type:jwt-bearer");
+
+                // .Result to make sure that the cache is filled-in before the controller tries to get access tokens
+                AuthenticationResult result = Application.AcquireTokenOnBehalfOfAsync(scopes, userAssertion).Result;
+                string acessTokenForGraphOBOUser = result.AccessToken;
+            }
+            catch (MsalException ex)
+            {
+                string message = ex.Message;
+                throw;
+            }
+        }
+
+        public void AddAccountToCacheFromAuthorizationCode(string authorizationCode)
+        {
+            string[] scopes = new string[] { "user.read" };
+            try
+            {
+                // .Result to make sure that the cache is filled-in before the controller tries to get access tokens
+                AuthenticationResult result = Application.AcquireTokenByAuthorizationCodeAsync(authorizationCode, scopes).Result;
+                string acessTokenForGraphOBOUser = result.AccessToken;
+            }
+            catch (MsalException ex)
+            {
+                string message = ex.Message;
+                throw;
+            }
+
+        }
+
+
+        /// <summary>
+        /// Gets an access token for a downstream API on behalf of the user which evidence are provided by the
+        /// <paramref name="user"/> parameter
+        /// </summary>
+        /// <param name="user">Account described by its claims</param>
+        /// <param name="scopes">Scopes to request for the downstream API to call</param>
+        /// <returns>An access token to call the downstream API characterized by its scopes, on behalf of the user</returns>
+        public async Task<string> GetAccessTokenOnBehalfOfUser(ClaimsPrincipal user, string[] scopes)
+        {
+            string userObjectId = user.FindFirstValue("http://schemas.microsoft.com/identity/claims/objectidentifier");
+            string tenantId = user.FindFirstValue("http://schemas.microsoft.com/identity/claims/tenantid");
+            if (string.IsNullOrWhiteSpace(userObjectId))
+            {
+                // TODO: find a better typed exception
+                throw new Exception("Missing claim 'http://schemas.microsoft.com/identity/claims/objectidentifier'");
+            }
+
+            if (string.IsNullOrWhiteSpace(tenantId))
+            {
+                throw new Exception("Missing claim 'http://schemas.microsoft.com/identity/claims/tenantid'");
+            }
+            string userId = userObjectId + "." + tenantId;
+            return await GetAccessTokenOnBehalfOfUser(userId, scopes);
+        }
+
+        /// <summary>
+        /// Gets an access token for a downstream API on behalf of the user which account ID is passed as an argument
+        /// </summary>
+        /// <param name="accountIdentifier">User account identifier for which to acquire a token. 
+        /// See <see cref="Microsoft.Identity.Client.AccountId.Identifier"/></param>
+        /// <param name="scopes">Scopes for the downstream API to call</param>
+        public async Task<string> GetAccessTokenOnBehalfOfUser(string accountIdentifier, string[] scopes)
+        {
+            var accounts = (await Application.GetAccountsAsync());
+
+            string accessToken = null;
+            try
+            {
+                AuthenticationResult result = null;
+                IAccount account = await Application.GetAccountAsync(accountIdentifier);
+                result = await Application.AcquireTokenSilentAsync(scopes, account);
+                accessToken = result.AccessToken;
+            }
+            catch (MsalException ex)
+            {
+                // TODO process the exception see if this is retryable etc ...
+                throw;
+            }
+
+            return accessToken;
+        }
+
+        /// <summary>
+        /// Access to the MSAL.NET confidential client application (for advanced scenarios)
+        /// </summary>
+        public ConfidentialClientApplication Application { get; private set; }
+
+        // Todo provide a better cache
+        static TokenCache userTokenCache = new TokenCache();
+
+        private void GetOrCreateApplication(AzureAdOptions options)
+        {
+            if (Application == null)
+            {
+
+                // This is a confidential client applicaiton, and therefore it shares with Azure AD client credentials (a client secret
+                // like here, but could also be a certificate)
+                ClientCredential clientCredential = new ClientCredential(options.ClientSecret);
+
+                // MSAL requests tokens from the Azure AD v2.0 endpoint
+                string authority = $"{options.Instance}{options.TenantId}/v2.0/";
+
+                Application = new ConfidentialClientApplication(options.ClientId, authority, options.RedirectUri,
+                                                                clientCredential, userTokenCache, appTokenCache: null);
+            }
+        }
+
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,33 +6,33 @@ level: 100
 service: ASP.NET Core Web App
 endpoint: AAD V2
 ---
-# Integrating Azure AD V2 into an ASP.NET Core web app that calls the Microsoft Graph
+# Integrating Azure AD V2 into an ASP.NET Core web app and calling the Microsoft Graph API on behalf of the user.
 
 ![Build badge](https://identitydivision.visualstudio.com/_apis/public/build/definitions/a7934fdd-dcde-4492-a406-7fad6ac00e17/514/badge)
 
 ## Scenario
 
-This sample shows how to build a .NET Core MVC Web app that uses OpenID Connect to sign in personal accounts (including outlook.com, live.com, and others) as well as work and school accounts from any company or organization that has integrated with Azure Active Directory The Web App then  calls the Microsoft Graph on behalf of the signed-in user. The sample leverages the ASP.NET Core OpenID Connect middleware and [MSAL.NET](http://aka.ms/msalnet)
+This sample shows how to build a .NET Core MVC Web app that uses OpenID Connect to sign in personal accounts (including outlook.com, live.com, and others) as well as work and school accounts from any company or organization that has integrated with Azure Active Directory. The Web App then calls Microsoft Graph on behalf of the signed-in user. The sample leverages the ASP.NET Core OpenID Connect middleware and [MSAL.NET](http://aka.ms/msalnet)
 
-> This is the second tutorial, building on top of the previous one (in the master branch) showing how to add sign-in to a Web application. This ones adds the part which is about calling the Microsoft Graph in a controller on behalf of the user
+> This second tutorial builds on top of the previous one (in the master branch), which shows how to add sign-in to a Web application. This one shows how to call Microsoft Graph in a controller on behalf of the user.
 
 ## How to run this sample
 
 To run this sample:
 
-> Pre-requisites: go through how to run this sample from the master branch. This page only shows the increment.
+> Pre-requisites: go through how to run [this sample from the master branch](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2). This page shows the incremental change required to call the Microsoft Graph API on behalf of a user that has successfully signed in to the web app.
 
 ### Step 1: Register the sample with your Azure AD tenant
 
-When you have registered your app as described in [the first tutorial](Step 1: Register the sample with your Azure AD tenant), you need an extra step:
+When you have registered your app as described in [the first tutorial](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2), you need an extra step:
 
-1. In the Application Secrets, section, click on **Generate New Password** and copy the value of the generated password. This value is now be needed for your Web App to call a Web API. Indeed, for this to happen, the Web App needs to get an access token for the Web API. This will be done using  MSAL.NET `ConfidentialClientApplication` and Confidential client application share a secret with Azure AD proving their identity.
+1. In the Application Secrets, section, click on **Generate New Password** and copy the value of the generated password. This value is needed for your Web App to call a Web API. For this to happen, the Web App needs to get an access token for the Web API. This will be done using MSAL.NET `ConfidentialClientApplication` which will share a secret with Azure AD to prove the Web Apps identity.
 
-1. Save the changes in the page
+1. Save the changes
 
 ### Step 2: Download/ Clone this sample code or build the application using a template
 
-This sample was created from the dotnet core 2.0 [dotnet new mvc](https://docs.microsoft.com/dotnet/core/tools/dotnet-new?tabs=netcore2x) template with `SingleOrg` authentication, and then tweaked to let it support tokens for the Azure AD V2 endpoint. You can clone/download this repository
+This sample was created from the dotnet core 2.0 [dotnet new mvc](https://docs.microsoft.com/dotnet/core/tools/dotnet-new?tabs=netcore2x) template with `SingleOrg` authentication, and then modified to let it support tokens for the Azure AD V2 endpoint. You can clone/download this repository
 
 You can clone this sample from your shell or command line:
 
@@ -51,24 +51,24 @@ You can clone this sample from your shell or command line:
 
 1. Build the solution and run it.
 
-2. Open your web browser and make a request to the app. The app immediately attempts to authenticate you via the Azure AD v2 endpoint. Sign in with your personal account or with work or school account.
+2. Open your web browser and make a request to the app. The app immediately attempts to authenticate you via the Azure AD v2 endpoint. Sign in with your personal account or with a work or school account.
 
 3. Go to the Contacts page, you should now see all kind of information about yourself (a call was made to the Microsoft Graph *me* endpoint)
 
 ## About The code
 
-Starting from the previous tutorial, the code was  incrementally updated by  following these steps:
+Starting from the [previous tutorial](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2), the code was incrementally updated by following these steps:
 
 ### Add a NuGet package reference to Microsoft.Identity.Client
 
-Using the NuGet package manager, reference Microsoft.Identity.Client (which is still in preview, so check "include preview")
+Using the NuGet package manager, reference Microsoft.Identity.Client (which is still in preview, so check "include preview" box)
 
 ### Add additional files to support token acquisition
 
 1. Add the `Extensions\ITokenAcquisition.cs`, `Extensions\TokenAcquisition.cs`. These files define a token acquisition service leveraging MSAL.NET, which is used in the existing application by dependency injection.
-1. Add the `Extensions\AuthPropertiesTokenCacheHelper .cs` file. This file proposes a cache for MSAL.NET Confidential client application based on AuthProperties (which are an ASP.NET concept) backed by Cookies.
+1. Add the `Extensions\AuthPropertiesTokenCacheHelper.cs` file. This file proposes a cache for MSAL.NET Confidential client application based on AuthProperties (which are an ASP.NET concept) backed by Cookies.
 
-### Update the startup.cs file to enable TokenAcquisition service
+### Update the `Startup.cs` file to enable TokenAcquisition service
 
 In the `Startup.cs` file, insert a call to:
 
@@ -82,9 +82,9 @@ before:
 services.AddMvc();
 ```
 
-### Hook-up to the Authorization code received event to populate the token cache with a token for the user
+### Hook-up to the `OnAuthorizationCodeReceived` event to populate the token cache with a token for the user
 
-Once the user has signed-in, the ASP.NET middleware gives an opportunity to the Web App to be notified of events such as the fact that an authorization code was received. The following code hooks-up to the `OnAuthorizationCodeReceived` event in order to redeem the code itself and therefore acquire a token, which then will be cached so that it can be used later in the application (in particular in the controllers)
+Once the user has signed-in, the ASP.NET middleware provides the Web App with the ability to be notified of events such as the fact that an authorization code was received. The following code hooks-up to the `OnAuthorizationCodeReceived` event in order to redeem the code itself and therefore acquire a token, which then will be cached so that it can be used later in the application (in particular in the controllers)
 
 1. In the `Extensions/AzureAdAuthenticationBuilderExtensions.cs` file:
    1. Add a private property to the `ConfigureAzureOptions` class.
@@ -93,7 +93,7 @@ Once the user has signed-in, the ASP.NET middleware gives an opportunity to the 
       private readonly ITokenAcquisition _tokenAcquisition;
       ```
 
-   1. Change the constructor of `ConfigureAzureOptions` to have a `ITokenAcquisition`. This will be provided by the ASP.NET Core framework using dependency injection, thanks to the call to `services.AddTokenAcquisition();` in `startup.cs`. The constructor should be:
+   1. Change the constructor of `ConfigureAzureOptions` to have a `ITokenAcquisition` parameter. This will be provided by the ASP.NET Core framework using dependency injection, thanks to the call to `services.AddTokenAcquisition();` in `Startup.cs`. The constructor should be:
 
       ```CSharp
       public ConfigureAzureOptions(IOptions<AzureAdOptions> azureOptions, ITokenAcquisition tokenAcquisition)
@@ -103,7 +103,7 @@ Once the user has signed-in, the ASP.NET middleware gives an opportunity to the 
       }
       ```
 
-   1. In the `Configure(string name, OpenIdConnectOptions options)` method, after previous options,
+   1. In the `Configure(string name, OpenIdConnectOptions options)` method, add in the following changes after the options that are already there:
 
         ```CSharp
         options.Events = new OpenIdConnectEvents();
@@ -111,7 +111,7 @@ Once the user has signed-in, the ASP.NET middleware gives an opportunity to the 
         options.ResponseType = "code id_token";
         ```
 
-   1. Add the `OnAuthorizationCodeReceived` method. This method redeems the authentication code, acquires a token, and  caches it in the token cache so that controllers can then acquire a token for another (or the same) web app in the name of the user, using the on behalf of grant.
+   1. Add the `OnAuthorizationCodeReceived` method. This method redeems the authorization code, acquires a token, and  caches it in the token cache so that controllers can then acquire a token for another (or the same) web app in the name of the user, using the on behalf of grant.
 
         ```CSharp
         private async Task OnAuthorizationCodeReceived(AuthorizationCodeReceivedContext context)
@@ -134,7 +134,7 @@ Once the user has signed-in, the ASP.NET middleware gives an opportunity to the 
       private ITokenAcquisition tokenAcquisition;
       ```
 
-   1. Change the `Contact()` action so that it calls the Microsoft Graph me endpoint. In case a token cannot be acquired, a challenge is attempted
+   1. Change the `Contact()` action so that it calls the Microsoft Graph *me* endpoint. In case a token cannot be acquired, a challenge is attempted
   to re-sign-in the user.
 
       ```CSharp
@@ -179,10 +179,10 @@ Once the user has signed-in, the ASP.NET middleware gives an opportunity to the 
        }
        ```
 
-### Change the code of the Contacts view to display the me object
+### Change the code of the Contacts view to display the *me* object
 
 In `Views\Home\Contacts.cshtml`, insert the following code, which creates an
-HTML table displaying the properties of the me object as returned by Microsoft Graph
+HTML table displaying the properties of the *me* object as returned by Microsoft Graph.
 
 ```CSharp
 <table>
@@ -208,6 +208,6 @@ HTML table displaying the properties of the me object as returned by Microsoft G
 
 You can learn more about the tokens by looking at the following topics in MSAL.NET's conceptual documentation:
 
-- The [Authorization code flow](https://aka.ms/msal-net-authorization-code) which is used, after the user signed-in with Open ID Connect, in order to get a token, and cache it for a later use. See [TokenAcquisition L 107](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/blob/f99e913cc032e16c59b748241111e97108e87918/Extensions/TokenAcquisition.cs#L107) for details of this code
+- The [Authorization code flow](https://aka.ms/msal-net-authorization-code) which is used, after the user signed-in with Open ID Connect, in order to get a token and cache it for a later use. See [TokenAcquisition L 107](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/blob/f99e913cc032e16c59b748241111e97108e87918/Extensions/TokenAcquisition.cs#L107) for details of this code
 - [AcquireTokenSilent](https://aka.ms/msal-net-acquiretokensilent ) which is used by the controller to get an access token for the downstream API. See [TokenAcquisition L 168](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/blob/f99e913cc032e16c59b748241111e97108e87918/Extensions/TokenAcquisition.cs#L168) for details of this code
 - [Token cache serialization](msal-net-token-cache-serialization)

--- a/README.md
+++ b/README.md
@@ -6,92 +6,46 @@ level: 100
 service: ASP.NET Core Web App
 endpoint: AAD V2
 ---
-# Integrating Azure AD V2 into an ASP.NET Core web app
+# Integrating Azure AD V2 into an ASP.NET Core web app that calls the Microsoft Graph
 
 ![Build badge](https://identitydivision.visualstudio.com/_apis/public/build/definitions/a7934fdd-dcde-4492-a406-7fad6ac00e17/514/badge)
 
 ## Scenario
 
-This sample shows how to build a .NET Core MVC Web app that uses OpenID Connect to sign in personal accounts (including outlook.com, live.com, and others) as well as work and school accounts from any company or organization that has integrated with Azure Active Directory. It leverages the ASP.NET Core OpenID Connect middleware.
+This sample shows how to build a .NET Core MVC Web app that uses OpenID Connect to sign in personal accounts (including outlook.com, live.com, and others) as well as work and school accounts from any company or organization that has integrated with Azure Active Directory The Web App then  calls the Microsoft Graph on behalf of the signed-in user. The sample leverages the ASP.NET Core OpenID Connect middleware and [MSAL.NET](http://aka.ms/msalnet)
 
-![Sign-in with Azure AD](ReadmeFiles/sign-in.png)
-
-An on demand video was created for the Build 2018 event, featuring this scenario and this sample. See the video [Building Web App Solutions With Authentication](https://channel9.msdn.com/Events/Build/2018/THR5001), and the associated [PowerPoint deck](http://video.ch9.ms/sessions/c1f9c808-82bc-480a-a930-b340097f6cc1/SigninworkandschoolMSAusersWebApp.pptx)
+> This is the second tutorial, building on top of the previous one (in the master branch) showing how to add sign-in to a Web application. This ones adds the part which is about calling the Microsoft Graph in a controller on behalf of the user
 
 ## How to run this sample
 
 To run this sample:
 
-> Pre-requisites: Install .NET Core (for example for Windows) by following the instructions at [.NET and C# - Get Started in 10 Minutes](https://www.microsoft.com/net/core). In addition to developing on Windows, you can develop on [Linux](https://www.microsoft.com/net/core#linuxredhat), [Mac](https://www.microsoft.com/net/core#macos), or [Docker](https://www.microsoft.com/net/core#dockercmd).
+> Pre-requisites: go through how to run this sample from the master branch. This page only shows the increment.
 
 ### Step 1: Register the sample with your Azure AD tenant
 
-1. Sign in to the [Application registration portal](https://apps.dev.microsoft.com/portal/register-app) either using a personal Microsoft account (live.com or hotmail.com) or work or school account.
-1. Give a name to your Application, make sure that the *Guided Setup* option is **Unchecked**. Then press **Create**. The portal will assign your app a globally unique *Application ID* that you'll use later in your code.
-1. Click **Add Platform**, and select **Web**.
-1. In the Redirect URLs field, add `http://localhost:5000/` and `http://localhost:5000/signin-oidc`
+When you have registered your app as described in [the first tutorial](Step 1: Register the sample with your Azure AD tenant), you need an extra step:
 
-> Note: The base address in the **Sign-on URL** and **Logout URL** settings is `http://localhost:5000`. This localhost address allows the sample app to run insecurely from your local system. Port 5000 is the default port for the [Kestrel server](https://docs.microsoft.com/aspnet/core/fundamentals/servers/kestrel). Update these URLs if you configure the app for production use (for example, `https://www.contoso.com/signin-oidc` and `https://www.contoso.com/signout-oidc`).
+1. In the Application Secrets, section, click on **Generate New Password** and copy the value of the generated password. This value is now be needed for your Web App to call a Web API. Indeed, for this to happen, the Web App needs to get an access token for the Web API. This will be done using  MSAL.NET `ConfidentialClientApplication` and Confidential client application share a secret with Azure AD proving their identity.
+
+1. Save the changes in the page
 
 ### Step 2: Download/ Clone this sample code or build the application using a template
 
-This sample was created from the dotnet core 2.0 [dotnet new mvc](https://docs.microsoft.com/dotnet/core/tools/dotnet-new?tabs=netcore2x) template with `SingleOrg` authentication, and then tweaked to let it support tokens for the Azure AD V2 endpoint. You can clone/download this repository or create the sample from the command line:
-
-#### Option 1: Download/ clone this sample
+This sample was created from the dotnet core 2.0 [dotnet new mvc](https://docs.microsoft.com/dotnet/core/tools/dotnet-new?tabs=netcore2x) template with `SingleOrg` authentication, and then tweaked to let it support tokens for the Azure AD V2 endpoint. You can clone/download this repository
 
 You can clone this sample from your shell or command line:
 
   ```console
-  git clone https://github.com/Azure-Samples/active-directory-dotnet-webapp-openidconnect-aspnetcore.git
+  git clone https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2
+  git checkout signInAndCallMsGraph
   ```
 
-  In the **appsettings.json** file, replace the `ClientID` value with the *Application ID* from the application you just registered in Application Registration portal on *Step 1*.
+  In the appsettings.json file, replace:
 
-#### Option 2: Create the sample from the command line
-
-1. Run the following command to create a sample from the command line using the `SingleOrg` template:
-    ```console
-    dotnet new mvc --auth SingleOrg --client-id <Enter_the_Application_Id_here>
-    ```
-
-    > Note: Replace *`Enter_the_Application_Id_here`* with the *Application Id* from the application Id you just registered in the Application Registration Portal.
-
-2. Open **Extensions\AzureAdAuthenticationBuilderExtensions.cs** file and replace the `Configure` method with:
-
-    ```CSharp
-    public void Configure(string name, OpenIdConnectOptions options)
-    {
-        options.ClientId = _azureOptions.ClientId;
-        options.Authority = $"{_azureOptions.Instance}common/v2.0";   // V2 Endpoint
-        options.UseTokenLifetime = true;
-        options.RequireHttpsMetadata = false;
-        options.TokenValidationParameters.ValidateIssuer = false;     // accept any tenant
-    }
-    ```
-
-3. Modify `Views\Shared\_LoginPartial.cshtml` to have the following content:
-
-    ```CSharp
-    @using System.Security.Claims
-
-    @if (User.Identity.IsAuthenticated)
-    {
-        var identity = User.Identity as ClaimsIdentity; // Azure AD V2 endpoint specific
-        string preferred_username = identity.Claims.FirstOrDefault(c => c.Type == "preferred_username")?.Value;
-        <ul class="nav navbar-nav navbar-right">
-            <li class="navbar-text">Hello @preferred_username</li>
-            <li><a asp-area="" asp-controller="Account" asp-action="SignOut">Sign out</a></li>
-        </ul>
-    }
-    else
-    {
-        <ul class="nav navbar-nav navbar-right">
-            <li><a asp-area="" asp-controller="Account" asp-action="Signin">Sign in</a></li>
-        </ul>
-    }
-    ```
-
-    > Note: This change is needed because certain token claims from Azure AD V1 endpoint (on which the original .NET core template is based) are different than Azure AD V2 endpoint.
+- the `ClientID` value with the *Application ID* from the application you registered in Application Registration portal,
+- the `TenantId` by `common`,
+- and the `ClientSecret` by the password you generated.
 
 ### Step 3: Run the sample
 
@@ -99,75 +53,161 @@ You can clone this sample from your shell or command line:
 
 2. Open your web browser and make a request to the app. The app immediately attempts to authenticate you via the Azure AD v2 endpoint. Sign in with your personal account or with work or school account.
 
-## Optional: Restrict sign-in access to your application
-
-By default, when you use the dotnet core template with `SingleOrg` authentication option and follow the instructions in this guide to configure the application to use the Azure Active Directory v2 endpoint, both personal accounts - like outlook.com, live.com, and others - as well as Work or school accounts from any organizations that are integrated with Azure AD can sign in to your application. This is typically used on SaaS applications.
-
-To restrict who can sign in to your application, use one of the options:
-
-### Option 1: Restrict access to a single organization (single-tenant)
-
-You can restrict sign-in access for your application to only user accounts that are in a single Azure AD tenant - including *guest accounts* of that tenant. This scenario is a common for *line-of-business applications*:
-
-1. Open **appsettings.json** and replace the line containing the `TenantId` value with the domain of your tenant, for example, *contoso.onmicrosoft.com* or the guid for the Tenant Id:
-
-    ```json
-    "TenantId": "[Enter the domain of your tenant, e.g. contoso.onmicrosoft.com or the Tenant Id]",
-    ```
-
-2. In your **Extensions\AzureAdAuthenticationBuilderExtensions.cs** file, replace the `Configure` method with:
-
-    ```CSharp
-    public void Configure(string name, OpenIdConnectOptions options)
-    {
-        options.ClientId = _azureOptions.ClientId;
-        options.Authority = $"{_azureOptions.Instance}{_azureOptions.TenantId}/v2.0";   // V2 Endpoint
-        options.UseTokenLifetime = true;
-        options.RequireHttpsMetadata = false;
-        options.TokenValidationParameters.ValidateIssuer = true;     // Validate the tenant
-    }
-    ```
-
-### Option 2: Restrict access to a list of organizations
-
-You can restrict sign-in access to only user accounts that are in a specific list of Azure AD organizations:
-
-1. In your **Extensions\AzureAdAuthenticationBuilderExtensions.cs** file, set the `ValidateIssuer` argument to **`true`**
-2. Add a `ValidIssuers` `TokenValidationParameters` parameter containing the list of allowed organizations.
-
-### Option 3: Use a custom method to validate issuers
-
-You can implement a custom method to validate issuers by using the **IssuerValidator** parameter. For more information about how to use this parameter, read about the [TokenValidationParameters class](https://msdn.microsoft.com/library/system.identitymodel.tokens.tokenvalidationparameters.aspx) on MSDN.
-
-### Variations
-
-You can also decide which types of user accounts can sign in to your Web App by changing the Authority. The picture below shows all the possibilities
-
-![Variations](ReadmeFiles/v2-variations.png)
+3. Go to the Contacts page, you should now see all kind of information about yourself (a call was made to the Microsoft Graph *me* endpoint)
 
 ## About The code
 
-This sample shows how to use the OpenID Connect ASP.NET Core middleware to sign in users from a single Azure AD tenant. The middleware is initialized in the `Startup.cs` file by passing it the Client ID of the app and the URL of the Azure AD tenant where the app is registered, which is read from the `appsettings.json` file. The middleware takes care of:
+Starting from the previous tutorial, the code was  incrementally updated by  following these steps:
 
-- Downloading the Azure AD metadata, finding the signing keys, and finding the issuer name for the tenant.
-- Processing OpenID Connect sign-in responses by validating the signature and issuer in an incoming JWT, extracting the user's claims, and putting the claims in `ClaimsPrincipal.Current`.
-- Integrating with the session cookie ASP.NET Core middleware to establish a session for the user.
+### Add a NuGet package reference to Microsoft.Identity.Client
 
-You can trigger the middleware to send an OpenID Connect sign-in request by decorating a class or method with the `[Authorize]` attribute or by issuing a challenge (see the `AccountController.cs` file):
+Using the NuGet package manager, reference Microsoft.Identity.Client (which is still in preview, so check "include preview")
 
-```csharp
-return Challenge(
-    new AuthenticationProperties { RedirectUri = redirectUrl },
-    OpenIdConnectDefaults.AuthenticationScheme);
+### Add additional files to support token acquisition
+
+1. Add the `Extensions\ITokenAcquisition.cs`, `Extensions\TokenAcquisition.cs`. These files define a token acquisition service leveraging MSAL.NET, which is used in the existing application by dependency injection.
+1. Add the `Extensions\AuthPropertiesTokenCacheHelper .cs` file. This file proposes a cache for MSAL.NET Confidential client application based on AuthProperties (which are an ASP.NET concept) backed by Cookies.
+
+### Update the startup.cs file to enable TokenAcquisition service
+
+In the `Startup.cs` file, insert a call to:
+
+```CSharp
+services.AddTokenAcquisition();
 ```
 
-Similarly, you can send a sign-out request:
+before:
 
-```csharp
-return SignOut(
-    new AuthenticationProperties { RedirectUri = callbackUrl },
-    CookieAuthenticationDefaults.AuthenticationScheme,
-    OpenIdConnectDefaults.AuthenticationScheme);
+```CSharp
+services.AddMvc();
 ```
 
-The middleware in this project is created as a part of the open-source [ASP.NET Security](https://github.com/aspnet/Security) project.
+### Hook-up to the Authorization code received event to populate the token cache with a token for the user
+
+Once the user has signed-in, the ASP.NET middleware gives an opportunity to the Web App to be notified of events such as the fact that an authorization code was received. The following code hooks-up to the `OnAuthorizationCodeReceived` event in order to redeem the code itself and therefore acquire a token, which then will be cached so that it can be used later in the application (in particular in the controllers)
+
+1. In the `Extensions/AzureAdAuthenticationBuilderExtensions.cs` file:
+   1. Add a private property to the `ConfigureAzureOptions` class.
+
+      ```CSharp
+      private readonly ITokenAcquisition _tokenAcquisition;
+      ```
+
+   1. Change the constructor of `ConfigureAzureOptions` to have a `ITokenAcquisition`. This will be provided by the ASP.NET Core framework using dependency injection, thanks to the call to `services.AddTokenAcquisition();` in `startup.cs`. The constructor should be:
+
+      ```CSharp
+      public ConfigureAzureOptions(IOptions<AzureAdOptions> azureOptions, ITokenAcquisition tokenAcquisition)
+      {
+       _azureOptions = azureOptions.Value;
+       _tokenAcquisition = tokenAcquisition;
+      }
+      ```
+
+   1. In the `Configure(string name, OpenIdConnectOptions options)` method, after previous options,
+
+        ```CSharp
+        options.Events = new OpenIdConnectEvents();
+        options.Events.OnAuthorizationCodeReceived = OnAuthorizationCodeReceived;
+        options.ResponseType = "code id_token";
+        ```
+
+   1. Add the `OnAuthorizationCodeReceived` method. This method redeems the authentication code, acquires a token, and  caches it in the token cache so that controllers can then acquire a token for another (or the same) web app in the name of the user, using the on behalf of grant.
+
+        ```CSharp
+        private async Task OnAuthorizationCodeReceived(AuthorizationCodeReceivedContext context)
+        {
+         string[] scopes = new string[] { "user.read" };
+         await _tokenAcquisition.AddAccountToCacheFromAuthorizationCode(context, scopes);
+        }
+        ```
+
+### Change the controller code to acquire a token and call Microsoft Graph
+
+1. In the `Controllers\HomeController.cs`file:
+   1. Add a constructor to HomeController, making the ITokenAcquisition service available (used by the ASP.NET dependency injection mechanism)
+
+      ```CSharp
+      public HomeController(ITokenAcquisition tokenAcquisition)
+      {
+       this.tokenAcquisition = tokenAcquisition;
+      }
+      private ITokenAcquisition tokenAcquisition;
+      ```
+
+   1. Change the `Contact()` action so that it calls the Microsoft Graph me endpoint. In case a token cannot be acquired, a challenge is attempted
+  to re-sign-in the user.
+
+      ```CSharp
+      public async Task<IActionResult> Contact()
+      {
+       string[] scopes = new string[] { "user.read" };
+       try
+        {
+         string accessToken = await tokenAcquisition.GetAccessTokenOnBehalfOfUser(HttpContext, User, scopes);
+         dynamic me = await CallGraphApiOnBehalfOfUser(accessToken);
+
+         ViewData["Me"] = me;
+         return View();
+        }
+        catch(MsalException)
+        {
+         var redirectUrl = Url.Action(nameof(HomeController.Contact), "Home");
+         return Challenge(
+                new AuthenticationProperties { RedirectUri = redirectUrl, IsPersistent = true },
+                                               OpenIdConnectDefaults.AuthenticationScheme);
+        }
+       }
+
+       private static async Task<dynamic> CallGraphApiOnBehalfOfUser(string accessToken)
+       {
+        //
+        // Call the Graph API and retrieve the user's profile.
+        //
+        HttpClient client = new HttpClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        HttpResponseMessage response = await client.GetAsync("https://graph.microsoft.com/Beta/me");
+        string content = await response.Content.ReadAsStringAsync();
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            dynamic me = JsonConvert.DeserializeObject(content);
+            return me;
+        }
+        else
+        {
+            throw new Exception(content);
+        }
+       }
+       ```
+
+### Change the code of the Contacts view to display the me object
+
+In `Views\Home\Contacts.cshtml`, insert the following code, which creates an
+HTML table displaying the properties of the me object as returned by Microsoft Graph
+
+```CSharp
+<table>
+    <tr>
+        <td>Property</td>
+        <td>Value</td>
+    </tr>
+    @{
+        Newtonsoft.Json.Linq.JObject me = ViewData["me"] as Newtonsoft.Json.Linq.JObject;
+        IEnumerable<Newtonsoft.Json.Linq.JProperty> children = me.Properties();
+        foreach (Newtonsoft.Json.Linq.JProperty child in children)
+        {
+                <tr>
+                    <td>@child.Name</td>
+                    <td>@child.Value<td>
+                </tr>
+        }
+    }
+</table>
+```
+
+## Learn more
+
+You can learn more about the tokens by looking at the following topics in MSAL.NET's conceptual documentation:
+
+- The [Authorization code flow](https://aka.ms/msal-net-authorization-code) which is used, after the user signed-in with Open ID Connect, in order to get a token, and cache it for a later use. See [TokenAcquisition L 107](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/blob/f99e913cc032e16c59b748241111e97108e87918/Extensions/TokenAcquisition.cs#L107) for details of this code
+- [AcquireTokenSilent](https://aka.ms/msal-net-acquiretokensilent ) which is used by the controller to get an access token for the downstream API. See [TokenAcquisition L 168](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/blob/f99e913cc032e16c59b748241111e97108e87918/Extensions/TokenAcquisition.cs#L168) for details of this code
+- [Token cache serialization](msal-net-token-cache-serialization)

--- a/Startup.cs
+++ b/Startup.cs
@@ -30,8 +30,7 @@ namespace WebApp_OpenIDConnect_DotNet
             .AddCookie();
 
             // Token service
-            services.Configure<AzureAdOptions>(myoptions => { });
-            services.AddSingleton<ITokenAcquisition, TokenAcquisition>();
+            services.AddTokenAcquisition();
 
             services.AddMvc();
         }

--- a/Startup.cs
+++ b/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using TodoListService.Extensions;
 
 namespace WebApp_OpenIDConnect_DotNet
 {
@@ -27,6 +28,10 @@ namespace WebApp_OpenIDConnect_DotNet
             })
             .AddAzureAd(options => Configuration.Bind("AzureAd", options))
             .AddCookie();
+
+            // Token service
+            services.Configure<AzureAdOptions>(myoptions => { });
+            services.AddSingleton<ITokenAcquisition, TokenAcquisition>();
 
             services.AddMvc();
         }

--- a/Startup.cs
+++ b/Startup.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using TodoListService.Extensions;
 
 namespace WebApp_OpenIDConnect_DotNet
 {

--- a/Views/Home/Contact.cshtml
+++ b/Views/Home/Contact.cshtml
@@ -4,6 +4,24 @@
 <h2>@ViewData["Title"]</h2>
 <h3>@ViewData["Message"]</h3>
 
+<table>
+    <tr>
+        <td>Property</td>
+        <td>Value</td>
+    </tr>
+    @{
+        Newtonsoft.Json.Linq.JObject me = ViewData["me"] as Newtonsoft.Json.Linq.JObject;
+        IEnumerable<Newtonsoft.Json.Linq.JProperty> children = me.Properties();
+        foreach (Newtonsoft.Json.Linq.JProperty child in children)
+        {
+                <tr>
+                    <td>@child.Name</td>
+                    <td>@child.Value<td>
+                </tr>
+        }
+    }
+</table>
+
 <address>
     One Microsoft Way<br />
     Redmond, WA 98052-6399<br />

--- a/WebApp-OpenIDConnect-DotNet.csproj
+++ b/WebApp-OpenIDConnect-DotNet.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="2.0.0-internal23101dev" />
   </ItemGroup>
 
   <ItemGroup>

--- a/appsettings.json
+++ b/appsettings.json
@@ -7,7 +7,7 @@
     "CallbackPath": "/signin-oidc",
 
     // Calling the Microsoft Graph
-    "ClientSecret": "[Copy the client secret added to teh app from the Azure portal]"
+    "ClientSecret": "[Copy the client secret added to the app from the Azure portal]"
 
   },
   "Logging": {

--- a/appsettings.json
+++ b/appsettings.json
@@ -4,7 +4,12 @@
     "Domain": "[Enter the domain of your tenant, e.g. contoso.onmicrosoft.com]",
     "TenantId": "[Enter the Tenant Id (Obtained from the Azure portal. Select 'Endpoints' from the 'App registrations' blade and use the GUID in any of the URLs), e.g. da41245a5-11b3-996c-00a8-4d99re19f292]",
     "ClientId": "[Enter the Client Id (Application ID obtained from the Azure portal), e.g. ba74781c2-53c2-442a-97c2-3d60re42f403]",
-    "CallbackPath": "/signin-oidc"
+    "CallbackPath": "/signin-oidc",
+
+    // Calling the Microsoft Graph
+    "RedirectUri": "http://localhost:3110/signin-oidc",
+    "ClientSecret": "[Copy the client secret added to teh app from the Azure portal]"
+
   },
   "Logging": {
     "IncludeScopes": false,

--- a/appsettings.json
+++ b/appsettings.json
@@ -7,7 +7,6 @@
     "CallbackPath": "/signin-oidc",
 
     // Calling the Microsoft Graph
-    "RedirectUri": "http://localhost:3110/signin-oidc",
     "ClientSecret": "[Copy the client secret added to teh app from the Azure portal]"
 
   },


### PR DESCRIPTION
** DO NOT MERGE ** until MSAL.NET 2.0.0-preview has released

## Purpose
This PR introduces an incremental improvement, changing the ASP.NET Core application from a Web App signing-in user only (using OpenID connect) to a Web app signing-in users and calling the Microsoft Graph

## Does this introduce a breaking change?

```
[ ] Yes
[x ] No
```

## Pull Request Type
Incremental improvement

```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2
cd active-directory-aspnetcore-webapp-openidconnect-v2
git checkout jmprieur/signInAndCallGraph
```

* Test the code
Go through the steps in the Readme.md of the branch (which references the readme.md of this branch)
In the app registration portal, add a client secret, as well as a ClientSecret setting in the appsettings.json
Run the application
```

## What to Check
- Verify that going to the Contacts page, you see information about yourself
- Verify that the links work

## Other Information

Links were provided to msal.net's conceptual documentation.

