### PR TITLE
Process incremental consent by sending a challenge to the user.

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -64,6 +64,7 @@ namespace WebApp_OpenIDConnect_DotNet.Controllers
         private AuthenticationProperties BuildAuthenticationPropertiesForIncrementalConsent(string[] scopes)
         {
             AuthenticationProperties properties = new AuthenticationProperties();
+            const string msaTenantId = "9188040d-6c67-4c5b-b112-36a304b66dad";
 
             // Set the scopes, including the scopes that ADAL.NET / MASL.NET need for the Token cache
             string[] additionalBuildInScopes = new string[] { "openid", "offline_access", "profile" };
@@ -75,6 +76,21 @@ namespace WebApp_OpenIDConnect_DotNet.Controllers
             if (!string.IsNullOrWhiteSpace(displayName))
             {
                 properties.SetParameter<string>(OpenIdConnectParameterNames.LoginHint, displayName);
+
+                string tenantId = HttpContext.User.FindFirstValue("http://schemas.microsoft.com/identity/claims/tenantid");
+                if (!string.IsNullOrWhiteSpace(tenantId))
+                {
+                    string domainHint;
+                    if (tenantId == msaTenantId)
+                    {
+                        domainHint = "consumers";
+                    }
+                    else
+                    {
+                        domainHint = "organizations";
+                    }
+                    properties.SetParameter<string>(OpenIdConnectParameterNames.DomainHint, domainHint);
+                }
             }
 
             return properties;

--- a/Extensions/ITokenAcquisition.cs
+++ b/Extensions/ITokenAcquisition.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Identity.Client;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/Extensions/TokenAcquisition.cs
+++ b/Extensions/TokenAcquisition.cs
@@ -115,6 +115,14 @@ namespace Microsoft.AspNetCore.Authentication
                 context.HandleCodeRedemption();
 
                 var application = CreateApplication(context.HttpContext, context.Principal, context.Properties, null);
+
+                // When redeeming a token, MSAL.NET's AcquireTokenByAuthorizationCodeAsync method should not look at the cache. It does for the moment
+                // Until this is fixed, removing the account
+                var account = await application.GetAccountAsync(context.Principal.GetMsalAccountId());
+                if (account!=null)
+                {
+                    await application.RemoveAsync(account);
+                }
                 var result = await application.AcquireTokenByAuthorizationCodeAsync(context.ProtocolMessage.Code, scopes.Except(scopesRequestedByMsalNet));
                 context.HandleCodeRedemption(result.AccessToken, result.IdToken);
             }


### PR DESCRIPTION
## Purpose
- Process incremental consent by sending a challenge to the user.
- Working around an issue with AcquireTokenByAuthorizationCodeAsync in MSAL.NET hitting the cache whereas it should not (MSAL.NET bug #[693](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/693))

## Does this introduce a breaking change?
```
[ ] Yes
[ x] No
```
This is an incremental change ensuring that whatever scope is requested in the Controller, the user will be prompted for incremental consent. 

Doing this I hit a bug that `AcquireTokenByAuthorizationCodeAsync` looks for tokens in the cache, and retuns it even if the new token has more scopes.

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
[x] Workaround to an MSAL.NET bug #[693](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/693)
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
1. Run the Web site under the debugger
1. sign-in
1. Select **Contact**
   => you should see information about youself (from the graph)
1. Put a breakpoint in the HomeController.Contact() method
   ```CSharp
   public async Task<IActionResult> Contact()
   {
    var scopes = new string[] { "user.read" };
     . . .
   ```
1. In the web site click on contact again.
1. Now in edit and continue more change the scope to "Mail.Send"
1. Continue the debugger
   => you'll notice the step-up experience. you are asked for incremental consent and the Contact page is displayed again.
