### PR TITLE
Redundant and erroneous reference to API version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You can clone this sample from your shell or command line:
     ```CSharp
     services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, options =>
     {
-        options.Authority = options.Authority + "/v2.0/";
+        options.Authority = options.Authority";
         options.TokenValidationParameters.ValidateIssuer = false;
     });
     ```


### PR DESCRIPTION
## Purpose
The README.md instructions tell the user to add some erroneous code. This pull request corrects the README.md so the user adds the right code. The error is that options.Authority already contains the API version but README.md instructs the user to add the API version to the options.Authority string.

## Does this introduce a breaking change?
[ ] Yes
[x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:

## How to Test
*  Get the code
*  Follow the steps in README.md

## What to Check
Verify that the following are valid
*  options.Authority should always include the API version in the return string.