### PR TITLE
Fix issue 130 - Clear token cache

### DIFF
--- a/Microsoft.Identity.Web/Client/TokenAcquisition.cs
+++ b/Microsoft.Identity.Web/Client/TokenAcquisition.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Identity.Web.Client
 
             if (account != null)
             {
-                this.UserTokenCacheProvider?.Clear(account.HomeAccountId.Identifier);
+                this.UserTokenCacheProvider?.Clear(user.GetMsalAccountId());
 
                 await app.RemoveAsync(account);
             }


### PR DESCRIPTION
Fix for [issue 130](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/issues/130)

## Purpose
When clearing the cache, we should pass user.GetMsalAccountId() because that is the cache key pattern that we are using. The previous code `account.HomeAccountId.Identifier` results in a bug for Guest accounts because Account Identifier has a different value than GetMsalAccountId(), resulting in not clearing the proper cache.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Using the sample 2-2 Token Cache is easier to test this bug.
Remove all the existing data on table `UserTokenCache` to have a fresh scenario.

* Clone the sample, sign-in using a **Guest** account and check the table `UserTokenCache`. You should have one record there.
* Sign-out and check the table again. You will see that the record stills there.
* Checkout this branch and repeat the steps. The cache will be properly cleared.

## What to Check
You will notice that we save the caches using `user.GetMsalAccountId()` as the key, but when clearing the cache, we were using `account.HomeAccountId.Identifier`.

## Other Information
<!-- Add any other helpful information that may be needed here. -->