### PR TITLE
Clear token cache refactor

### DIFF
--- a/Microsoft.Identity.Web/Client/TokenAcquisition.cs
+++ b/Microsoft.Identity.Web/Client/TokenAcquisition.cs
@@ -282,9 +282,9 @@ namespace Microsoft.Identity.Web.Client
 
             if (account != null)
             {
-                this.UserTokenCacheProvider?.Clear(user.GetMsalAccountId());
-
                 await app.RemoveAsync(account);
+
+                this.UserTokenCacheProvider?.Clear(user.GetMsalAccountId());
             }
         }
 


### PR DESCRIPTION
This PR implements the suggestion discussed in this issue:https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/issues/130

## Purpose

Swapping the order of execution of `await app.RemoveAsync(account)` and `this.UserTokenCacheProvider?.Clear(user.GetMsalAccountId())` prevents a remaining empty JSON in the cache storage.

`app.RemoveAsync(account)` should be executed first, since the empty JSON is created there. Then we call `this.UserTokenCacheProvider?.Clear(user.GetMsalAccountId())` to wipe it out.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

Please follow the steps in the thread: https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/issues/130

## What to Check
Verify that the following are valid:
* The memory cache wont have an empty entry after logging out
