### PR TITLE
MsalUiRequiredExceptionFilterAttribute refactor

### DIFF
--- a/4-WebApp-your-API/Client/Controllers/TodoListController.cs
+++ b/4-WebApp-your-API/Client/Controllers/TodoListController.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using System.Collections.Generic;
+using Microsoft.Identity.Web.Client;
 using System.Threading.Tasks;
 using TodoListClient.Services;
 using TodoListService.Models;
@@ -10,7 +10,6 @@ namespace TodoListClient.Controllers
     public class TodoListController : Controller
     {
         private ITodoListService _todoListService;
-        private IList<Todo> Model = new List<Todo>();
 
         public TodoListController(ITodoListService todoListService)
         {
@@ -18,6 +17,7 @@ namespace TodoListClient.Controllers
         }
 
         // GET: TodoList
+        [MsalUiRequiredExceptionFilter(ScopeKeySection = "TodoList:TodoListScope")]
         public async Task<ActionResult> Index()
         {
             return View(await _todoListService.GetAsync());

--- a/4-WebApp-your-API/Client/Controllers/TodoListController.cs
+++ b/4-WebApp-your-API/Client/Controllers/TodoListController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Identity.Client;
 using Microsoft.Identity.Web.Client;
 using System.Threading.Tasks;
 using TodoListClient.Services;
@@ -18,8 +19,11 @@ namespace TodoListClient.Controllers
 
         // GET: TodoList
         [MsalUiRequiredExceptionFilter(ScopeKeySection = "TodoList:TodoListScope")]
+        //[ServiceFilter(typeof(MsalUiRequiredExceptionFilter))]
         public async Task<ActionResult> Index()
         {
+            // Uncomment for testing
+            // throw new MsalUiRequiredException(MsalError.UserNullError, "abcde", new MsalUiRequiredException(MsalError.UserNullError, "testing"));
             return View(await _todoListService.GetAsync());
         }
 

--- a/4-WebApp-your-API/Client/Controllers/TodoListController.cs
+++ b/4-WebApp-your-API/Client/Controllers/TodoListController.cs
@@ -19,11 +19,8 @@ namespace TodoListClient.Controllers
 
         // GET: TodoList
         [MsalUiRequiredExceptionFilter(ScopeKeySection = "TodoList:TodoListScope")]
-        //[ServiceFilter(typeof(MsalUiRequiredExceptionFilter))]
         public async Task<ActionResult> Index()
         {
-            // Uncomment for testing
-            // throw new MsalUiRequiredException(MsalError.UserNullError, "abcde", new MsalUiRequiredException(MsalError.UserNullError, "testing"));
             return View(await _todoListService.GetAsync());
         }
 

--- a/Microsoft.Identity.Web/Client/MsalUiRequiredExceptionFilterAttribute.cs
+++ b/Microsoft.Identity.Web/Client/MsalUiRequiredExceptionFilterAttribute.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Identity.Web.Client
                 if (CanBeSolvedByReSignInUser(msalUiRequiredException))
                 {
                     // the users cannot provide both scopes and ScopeKeySection at the same time
-                    if (!string.IsNullOrWhiteSpace(ScopeKeySection) && Scopes.Length > 0)
+                    if (!string.IsNullOrWhiteSpace(ScopeKeySection) && Scopes != null && Scopes.Length > 0)
                     {
                         throw new InvalidOperationException($"Either provide the '{nameof(ScopeKeySection)}' or the '{nameof(Scopes)}' to the 'MsalUiRequiredExceptionFilterAttribute'.");
                     }

--- a/Microsoft.Identity.Web/WebApiStartupHelpers.cs
+++ b/Microsoft.Identity.Web/WebApiStartupHelpers.cs
@@ -83,7 +83,6 @@ namespace Microsoft.Identity.Web
                 // be used from the controllers.
                 options.Events = new JwtBearerEvents();
 
-#pragma warning disable 1998
                 options.Events.OnTokenValidated = async context =>
                    {
                        // This check is required to ensure that the Web API only accepts tokens from tenants where it has been consented and provisioned.
@@ -93,9 +92,8 @@ namespace Microsoft.Identity.Web
                            throw new UnauthorizedAccessException("Neither scope or roles claim was found in the bearer token.");
                        }
 
-                       return;
+                       await Task.FromResult(0);
                    };
-#pragma warning restore 1998
 
                 // If you want to debug, or just understand the JwtBearer events, uncomment the following line of code
                 // options.Events = JwtBearerMiddlewareDiagnostics.Subscribe(options.Events);


### PR DESCRIPTION
## Purpose
Added a new parameter, `ScopeKeySection` so we can use values saved on the config file as the scope. Without this new parameter, it is not possible to do it due to the compilation error: `"an object reference is required for the non-static field, method, or property".`

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* You are able to use a value from the config file to get the scope
* `IConfiguration` is proper built, and optimized

## Other Information
The name `ScopeKeySection` is open for changes. Please send your suggestion =]
