### PR TITLE
Fix issue 158 - Share SQL token cache between different apps

### DIFF
--- a/2-WebApp-graph-user/2-2-TokenCache/README.md
+++ b/2-WebApp-graph-user/2-2-TokenCache/README.md
@@ -102,9 +102,18 @@ public void ConfigureServices(IServiceCollection services)
 The aforementioned four lines of code are explained below.
 
 1. The first two lines enable MSAL.NET to hook-up to the OpenID Connect events to redeem the authorization code obtained by the ASP.NET Core middleware. After obtaining a token for Microsoft Graph, it saves it into the token cache, for use by the Controllers.
-1. The last two lines hook up the Sql server database based token caching solution to MSAL.NET. The Sql based token cache requires a **Connection string** named `TokenCacheDbConnStr` available in the **ConnectionStrings** collections of the **appsettings.json** configuration file. 
+1. The last two lines hook up the Sql server database based token caching solution to MSAL.NET. The Sql based token cache requires a **Connection string** named `TokenCacheDbConnStr` available in the **ConnectionStrings** collections of the **appsettings.json** configuration file.
 
 The files `MSALAppSqlTokenCacheProvider.cs` and `MSALPerUserSqlTokenCacheProvider` of the `Microsoft.Identity.Web` project contains the app and per-user token cache implementations that use Sql server as the token cache.
+
+### Sharing the same Token Cache database between apps
+
+Since we are using `IDataProtector` to protect the token being persisted on the database, in order to enable it to be used between different apps, `SetApplicationName()` must be configured with the same value for all apps. You can read [more details about IDataProtector here.](https://docs.microsoft.com/en-us/aspnet/core/security/data-protection/configuration/overview?view=aspnetcore-2.2#setapplicationname)
+
+```csharp
+services.AddDataProtection()
+        .SetApplicationName("WebApp_Tutorial");
+```
 
 ## Next steps
 

--- a/4-WebApp-your-API/Client/Controllers/TodoListController.cs
+++ b/4-WebApp-your-API/Client/Controllers/TodoListController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Identity.Web.Client;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using TodoListClient.Services;
@@ -18,6 +19,7 @@ namespace TodoListClient.Controllers
         }
 
         // GET: TodoList
+        //[MsalUiRequiredExceptionFilter(ScopeKeySection = "TodoList:TodoListScope")]
         public async Task<ActionResult> Index()
         {
             return View(await _todoListService.GetAsync());

--- a/Microsoft.Identity.Web/Client/TokenCacheProviders/Sql/MSALAppSqlTokenCacheProviderExtension.cs
+++ b/Microsoft.Identity.Web/Client/TokenCacheProviders/Sql/MSALAppSqlTokenCacheProviderExtension.cs
@@ -90,7 +90,10 @@ namespace Microsoft.Identity.Web.Client.TokenCacheProviders
             //var tokenCacheDbContext = new TokenCacheDbContext(tokenCacheDbContextBuilder.Options);
             //tokenCacheDbContext.Database.EnsureCreated();
 
-            services.AddDataProtection();
+            // To share protected payloads among apps, configure SetApplicationName in each app with the same value. 
+            // https://docs.microsoft.com/en-us/aspnet/core/security/data-protection/configuration/overview?view=aspnetcore-2.2#setapplicationname
+            services.AddDataProtection()
+                .SetApplicationName("WebApp_Tutorial");
 
             services.AddDbContext<TokenCacheDbContext>(options =>
                 options.UseSqlServer(sqlTokenCacheOptions.SqlConnectionString));

--- a/Microsoft.Identity.Web/Client/TokenCacheProviders/Sql/MSALAppSqlTokenCacheProviderExtension.cs
+++ b/Microsoft.Identity.Web/Client/TokenCacheProviders/Sql/MSALAppSqlTokenCacheProviderExtension.cs
@@ -52,13 +52,13 @@ namespace Microsoft.Identity.Web.Client.TokenCacheProviders
         {
             // Uncomment the following lines to create the database. In production scenarios, the database
             // will most probably be already present.
-/*
+            /*
             var tokenCacheDbContextBuilder = new DbContextOptionsBuilder<TokenCacheDbContext>();
             tokenCacheDbContextBuilder.UseSqlServer(sqlTokenCacheOptions.SqlConnectionString);
 
             var tokenCacheDbContextForCreation = new TokenCacheDbContext(tokenCacheDbContextBuilder.Options);
             tokenCacheDbContextForCreation.Database.EnsureCreated();
-*/
+            */
             services.AddDataProtection();
 
             services.AddDbContext<TokenCacheDbContext>(options =>
@@ -84,11 +84,13 @@ namespace Microsoft.Identity.Web.Client.TokenCacheProviders
         {
             // Uncomment the following lines to create the database. In production scenarios, the database
             // will most probably be already present.
-            //var tokenCacheDbContextBuilder = new DbContextOptionsBuilder<TokenCacheDbContext>();
-            //tokenCacheDbContextBuilder.UseSqlServer(sqlTokenCacheOptions.SqlConnectionString);
+            /*
+            var tokenCacheDbContextBuilder = new DbContextOptionsBuilder<TokenCacheDbContext>();
+            tokenCacheDbContextBuilder.UseSqlServer(sqlTokenCacheOptions.SqlConnectionString);
 
-            //var tokenCacheDbContext = new TokenCacheDbContext(tokenCacheDbContextBuilder.Options);
-            //tokenCacheDbContext.Database.EnsureCreated();
+            var tokenCacheDbContextForCreation = new TokenCacheDbContext(tokenCacheDbContextBuilder.Options);
+            tokenCacheDbContextForCreation.Database.EnsureCreated();
+            */
 
             // To share protected payloads among apps, configure SetApplicationName in each app with the same value. 
             // https://docs.microsoft.com/en-us/aspnet/core/security/data-protection/configuration/overview?view=aspnetcore-2.2#setapplicationname


### PR DESCRIPTION
## Purpose
Fix for [issue #158](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/issues/158).

To be able to share the SQL token cache between two different apps, we need to set the same application name for the data protection.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Set two applications to use SQL Token Cache, then run both of them.

## What to Check
You will be able to use the same token cache entry on the DB
