### PR TITLE
Fix JwtBearerOptions not being correctly loaded (#177)

### DIFF
--- a/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
+++ b/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
@@ -41,7 +41,6 @@ namespace Microsoft.Identity.Web
             string configSectionName = "AzureAD",
             bool subscribeToJwtBearerMiddlewareDiagnosticsEvents = false)
         {
-            services.Configure<AzureADOptions>(options => configuration.Bind(configSectionName, options));
             services.AddAuthentication(AzureADDefaults.JwtBearerAuthenticationScheme)
                     .AddAzureADBearer(options => configuration.Bind(configSectionName, options));
 


### PR DESCRIPTION
Remove call to services.Configure<AzureADOptions>() introduced in commit d5166bb9.
The call causes the subsequent configuration of JwtBearerOptions based on a binding to the "AzureAD" config section to fail - JWT-specific properties like Authority and Audience are null.

## Purpose
Fix JwtBearerOptions not being correctly loaded (#177)

Remove call to services.Configure<AzureADOptions>() introduced in commit d5166bb9.
The call causes the subsequent configuration of JwtBearerOptions based on a binding to the "AzureAD" config section to fail - JWT-specific properties like Authority and Audience are null.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
Run the sample "4-WebApp-your-API"
```

## What to Check
Verify that the following are valid
* Running the sample should work and not result in an error "InvalidOperationException: The MetadataAddress or Authority must use HTTPS unless disabled for development by setting RequireHttpsMetadata=false."

## Other Information
<!-- Add any other helpful information that may be needed here. -->