### PR TITLE
Register IHttpContextAccessor required by TodoListController

### DIFF
--- a/4-WebApp-your-API/TodoListService/Startup.cs
+++ b/4-WebApp-your-API/TodoListService/Startup.cs
@@ -59,6 +59,8 @@ namespace TodoListService
                 options.TokenValidationParameters.NameClaimType = "name";
             });
 
+            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
         }
 


### PR DESCRIPTION
ASP.NET Core no longer automatically registers an instance of IHttpContextAccessor as required by TodoListController, leading to an exception in the constructor. Add a manual registration as recommended in https://github.com/aspnet/Hosting/issues/793.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix bug.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
Try out sample "4-WebApp-your-API" - without the fix, trying to instantiate the TodoListController will fail.
```

## What to Check
Verify that the following are valid
* Open the ToDoList in the Client and verify that is is correctly loaded from the Service.

## Other Information
<!-- Add any other helpful information that may be needed here. -->