### PR TITLE
Make sure roles claims end up as actual role claims for use with Auth…

### DIFF
--- a/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
+++ b/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
@@ -85,6 +85,19 @@ namespace Microsoft.Identity.Web
                            throw new UnauthorizedAccessException("Neither scope or roles claim was found in the bearer token.");
                        }
 
+                       // Make sure roles claims end up as actual role claims for use with Authorize("Role={RoleName}") attribute and User.IsInRole({RoleName})
+                       if (context.Principal.Claims.Any(x => x.Type == ClaimConstants.Roles))
+                       {
+                           ClaimsIdentity ci = context.Principal.Identity as ClaimsIdentity;
+                           if (ci != null)
+                           {
+                               foreach (var role in context.Principal.Claims.Where(w => w.Type == ClaimConstants.Roles).ToList())
+                               {
+                                   ci.AddClaim(new Claim(ci.RoleClaimType, role.Value));
+                               }
+                           }
+                       }
+
                        await Task.FromResult(0);
                    };
 


### PR DESCRIPTION
…orize("Role={RoleName}") attribute and User.IsInRole({RoleName})

## Purpose
Make sure roles claims end up as actual role claims for use with Authorize("Role={RoleName}") attribute and User.IsInRole({RoleName})

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/peterpde/active-directory-aspnetcore-webapp-openidconnect-v2.git
cd active-directory-aspnetcore-webapp-openidconnect-v2
git checkout AuthorizeRoles

* Test the code
1. Create Azure Ad application with application roles
2. Sign-in with user and pass bearer token to web api and test role with User.IsInRole("{RoleName"}) with Authorize attribute or Authorize(Roles="{RoleName}") attribute in controller method.
3. Best project folder for testing would be the "4-WebApp-your-API" solution folder

## What to Check
Verify that a user is or is not in the proper role

## Other Information