### PR TITLE
support for certificate (public keys) based authentication

### DIFF
--- a/Microsoft.Identity.Web/ConfidentialClientApplicationOptions.cs
+++ b/Microsoft.Identity.Web/ConfidentialClientApplicationOptions.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Identity.Client;
+
+namespace Microsoft.Identity.Web
+{
+    /// <summary>
+    /// Configuration options for a confidential client application
+    /// (Web app / Web API / daemon app). See https://aka.ms/msal-net/application-configuration
+    /// </summary>
+    public class ConfidentialClientApplicationOptions : ApplicationOptions
+    {
+        /// <summary>
+        /// Client secret for the confidential client application. This secret (application password)
+        /// is provided by the application registration portal, or provided to Azure AD during the
+        /// application registration with PowerShell AzureAD, PowerShell AzureRM, or Azure CLI.
+        /// </summary>
+        public string ClientSecret { get; set; }
+
+        /// <summary>
+        /// Location for private key certificate
+        /// </summary>
+        public string CertificateLocation { get; set; }
+
+        /// <summary>
+        /// Password for the private key certificate
+        /// </summary>
+        public string CertificatePassword { get; set; }
+    }
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
add supports certificate (public keys) based authentication when requesting tokens

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
Create a self sign certificate
export to pfx - note location and password
specify 'CertificateLocation' and 'CertificatePassword' as part of 'AzureAd' configuration (instead of ClientSecret)
export public keys for certificate and upload to azure
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
ensure you use 'AddMsal' as part of the web app startup
and confirm the user is able to sign in  (and receive a jwt token)
```

## What to Check
Verify that the following are valid
* while this works, is a better way of doing this?

## Other Information

