### PR TITLE
Removed documentation for parameter that no longer exists in IMsalTokenCacheProvider

### DIFF
--- a/Microsoft.Identity.Web/TokenCacheProviders/IMsalTokenCacheProvider .cs
+++ b/Microsoft.Identity.Web/TokenCacheProviders/IMsalTokenCacheProvider .cs
@@ -15,8 +15,6 @@ namespace Microsoft.Identity.Web.TokenCacheProviders
         /// Initializes a token cache (which can be a user token cache or an app token cache)
         /// </summary>
         /// <param name="tokenCache">Token cache for which to initialize the serialization</param>
-        /// <param name="isAppTokenCache">Is the token cache an App token cache or
-        /// a user token cache</param>
         /// <returns></returns>
         Task InitializeAsync(ITokenCache tokenCache);
 


### PR DESCRIPTION
Removed documentation for a parameter that no longer exists on a method on the IMsalTokenCacheProvider interface.

## Purpose
Minor correction to the XML documentation on a member of an interface.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type
Updating XML documentation on a refactored member.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ x ] Documentation content changes
[ ] Other... Please describe:
```