### PR TITLE
Fix issue 251

### DIFF
--- a/3-WebApp-multi-APIs/Controllers/HomeController.cs
+++ b/3-WebApp-multi-APIs/Controllers/HomeController.cs
@@ -52,7 +52,7 @@ namespace WebApp_OpenIDConnect_DotNet.Controllers
 
         // Requires that the app has added the Azure Service Management / user_impersonation scope, and that
         // the admin tenant does not require admin consent for ARM.
-        [AuthorizeForScopes(Scopes = new[] { "https://management.azure.com/user_impersonation", "user.read", "directory.read.all" })]
+        [AuthorizeForScopes(Scopes = new[] { "https://management.core.windows.net/user_impersonation", "user.read", "directory.read.all" })]
         public async Task<IActionResult> Tenants()
         {
             var accessToken =

--- a/3-WebApp-multi-APIs/README.md
+++ b/3-WebApp-multi-APIs/README.md
@@ -135,7 +135,7 @@ In the `Views\Home` folder add a view named `Tenants.cshtml`
 ```CSharp
   // Requires that the app has added the Azure Service Management / user_impersonation scope, and that
   // the admin tenant does not require admin consent for ARM.
-  [AuthorizeForScopes(Scopes = new[] { "https://management.azure.com/user_impersonation"})]
+  [AuthorizeForScopes(Scopes = new[] { "https://management.core.windows.net/user_impersonation"})]
   public async Task<IActionResult> Tenants()
   {
       var accessToken =

--- a/3-WebApp-multi-APIs/Services/ARM/ArmOperationsService.cs
+++ b/3-WebApp-multi-APIs/Services/ARM/ArmOperationsService.cs
@@ -35,7 +35,7 @@ namespace WebApp_OpenIDConnect_DotNet.Services.Arm
 
         // Use Azure Resource manager to get the list of a tenant accessible by a user
         // https://docs.microsoft.com/en-us/rest/api/resources/tenants/list
-        public static string ArmResource { get; } = "https://management.azure.com/";
+        public static string ArmResource { get; } = "https://management.core.windows.net/";
 
         protected string ArmListTenantUrl { get; } = "https://management.azure.com/tenants?api-version=2016-06-01";
     }


### PR DESCRIPTION
## Purpose
Fix issue: https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/issues/251

Changed ARM scope to "https://management.core.windows.net" so I can work for MT apps. This is a workaround since "https://management.azure.com" was supossed to work. ARM team is already investigating

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
- Create the sample as MT app (change tenantId to 'organizations')
- Sign-in with a guest tenant and click on "Tenants" menu

## What to Check
You will be able to access the screen