### PR TITLE
Same site cookie fix

### DIFF
--- a/1-WebApp-OIDC/1-1-MyOrg/Startup.cs
+++ b/1-WebApp-OIDC/1-1-MyOrg/Startup.cs
@@ -27,6 +27,7 @@ namespace WebApp_OpenIDConnect_DotNet
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
                 options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                // Handling SameSite cookie according to https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
                 options.HandleSameSiteCookieCompatibility();
             });
 

--- a/1-WebApp-OIDC/1-1-MyOrg/Startup.cs
+++ b/1-WebApp-OIDC/1-1-MyOrg/Startup.cs
@@ -26,7 +26,8 @@ namespace WebApp_OpenIDConnect_DotNet
             {
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                options.HandleSameSiteCookieCompatibility();
             });
 
             // Sign-in users with the Microsoft identity platform

--- a/1-WebApp-OIDC/1-1-MyOrg/WebApp-OpenIDConnect-DotNet.csproj
+++ b/1-WebApp-OIDC/1-1-MyOrg/WebApp-OpenIDConnect-DotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <!--<AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>-->
     <UserSecretsId>aspnet-WebApp_OpenIDConnect_DotNet-81EA87AD-E64D-4755-A1CC-5EA47F49B5D8</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>

--- a/1-WebApp-OIDC/1-2-AnyOrg/Startup.cs
+++ b/1-WebApp-OIDC/1-2-AnyOrg/Startup.cs
@@ -26,7 +26,9 @@ namespace WebApp_OpenIDConnect_DotNet
             {
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                // Handling SameSite cookie according to https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
+                options.HandleSameSiteCookieCompatibility();
             });
 
             // Sign-in users with the Microsoft identity platform

--- a/1-WebApp-OIDC/1-2-AnyOrg/WebApp-OpenIDConnect-DotNet.csproj
+++ b/1-WebApp-OIDC/1-2-AnyOrg/WebApp-OpenIDConnect-DotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>aspnet-WebApp_OpenIDConnect_DotNet-81EA87AD-E64D-4755-A1CC-5EA47F49B5D8</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
   </PropertyGroup>

--- a/1-WebApp-OIDC/1-3-AnyOrgOrPersonal/Startup.cs
+++ b/1-WebApp-OIDC/1-3-AnyOrgOrPersonal/Startup.cs
@@ -27,7 +27,9 @@ namespace WebApp_OpenIDConnect_DotNet
             {
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                // Handling SameSite cookie according to https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
+                options.HandleSameSiteCookieCompatibility();
             });
 
             // Sign-in users with the Microsoft identity platform

--- a/1-WebApp-OIDC/1-3-AnyOrgOrPersonal/WebApp-OpenIDConnect-DotNet.csproj
+++ b/1-WebApp-OIDC/1-3-AnyOrgOrPersonal/WebApp-OpenIDConnect-DotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>aspnet-WebApp_OpenIDConnect_DotNet-81EA87AD-E64D-4755-A1CC-5EA47F49B5D8</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
   </PropertyGroup>

--- a/1-WebApp-OIDC/1-4-Sovereign/Startup.cs
+++ b/1-WebApp-OIDC/1-4-Sovereign/Startup.cs
@@ -27,7 +27,9 @@ namespace WebApp_OpenIDConnect_DotNet
             {
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                // Handling SameSite cookie according to https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
+                options.HandleSameSiteCookieCompatibility();
             });
 
             // Sign-in users with the Microsoft identity platform

--- a/1-WebApp-OIDC/1-4-Sovereign/WebApp-OpenIDConnect-DotNet.csproj
+++ b/1-WebApp-OIDC/1-4-Sovereign/WebApp-OpenIDConnect-DotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>aspnet-WebApp_OpenIDConnect_DotNet-81EA87AD-E64D-4755-A1CC-5EA47F49B5D8</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
   </PropertyGroup>

--- a/1-WebApp-OIDC/1-5-B2C/Startup.cs
+++ b/1-WebApp-OIDC/1-5-B2C/Startup.cs
@@ -30,6 +30,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Identity.Web;
 
 namespace WebApp_OpenIDConnect_DotNet
 {
@@ -49,7 +50,9 @@ namespace WebApp_OpenIDConnect_DotNet
             {
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                // Handling SameSite cookie according to https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
+                options.HandleSameSiteCookieCompatibility();
             });
 
             // Configuration to sign-in users with Azure AD B2C

--- a/1-WebApp-OIDC/1-5-B2C/WebApp-OpenIDConnect-DotNet.csproj
+++ b/1-WebApp-OIDC/1-5-B2C/WebApp-OpenIDConnect-DotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>aspnet-WebApp_OpenIDConnect_DotNet-81EA87AD-E64D-4755-A1CC-5EA47F49B5D8</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
   </PropertyGroup>

--- a/1-WebApp-OIDC/1-5-B2C/WebApp-OpenIDConnect-DotNet.csproj
+++ b/1-WebApp-OIDC/1-5-B2C/WebApp-OpenIDConnect-DotNet.csproj
@@ -21,4 +21,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="3.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.Identity.Web\Microsoft.Identity.Web.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/1-WebApp-OIDC/1-5-B2C/WebApp-OpenIDConnect-DotNet.sln
+++ b/1-WebApp-OIDC/1-5-B2C/WebApp-OpenIDConnect-DotNet.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.29123.89
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApp-OpenIDConnect-DotNet", "WebApp-OpenIDConnect-DotNet.csproj", "{8DCFEEC2-0A85-4C7E-B96A-21C9184470B1}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Identity.Web", "..\..\Microsoft.Identity.Web\Microsoft.Identity.Web.csproj", "{DDD841C1-4657-4FE4-ABE1-529D02E03235}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{8DCFEEC2-0A85-4C7E-B96A-21C9184470B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8DCFEEC2-0A85-4C7E-B96A-21C9184470B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8DCFEEC2-0A85-4C7E-B96A-21C9184470B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DDD841C1-4657-4FE4-ABE1-529D02E03235}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DDD841C1-4657-4FE4-ABE1-529D02E03235}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DDD841C1-4657-4FE4-ABE1-529D02E03235}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DDD841C1-4657-4FE4-ABE1-529D02E03235}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/2-WebApp-graph-user/2-1-Call-MSGraph/Startup.cs
+++ b/2-WebApp-graph-user/2-1-Call-MSGraph/Startup.cs
@@ -30,7 +30,9 @@ namespace WebApp_OpenIDConnect_DotNet
             {
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                // Handling SameSite cookie according to https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
+                options.HandleSameSiteCookieCompatibility();
             });
 
             services.AddOptions();

--- a/2-WebApp-graph-user/2-1-Call-MSGraph/WebApp-OpenIDConnect-DotNet.csproj
+++ b/2-WebApp-graph-user/2-1-Call-MSGraph/WebApp-OpenIDConnect-DotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>aspnet-WebApp_OpenIDConnect_DotNet-81EA87AD-E64D-4755-A1CC-5EA47F49B5D8</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
   </PropertyGroup>

--- a/2-WebApp-graph-user/2-2-TokenCache/Startup.cs
+++ b/2-WebApp-graph-user/2-2-TokenCache/Startup.cs
@@ -30,7 +30,9 @@ namespace WebApp_OpenIDConnect_DotNet
             {
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                // Handling SameSite cookie according to https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
+                options.HandleSameSiteCookieCompatibility();
             });
 
             // This is required to be instantiated before the OpenIdConnectOptions starts getting configured.

--- a/2-WebApp-graph-user/2-2-TokenCache/WebApp-OpenIDConnect-DotNet.csproj
+++ b/2-WebApp-graph-user/2-2-TokenCache/WebApp-OpenIDConnect-DotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>aspnet-WebApp_OpenIDConnect_DotNet-81EA87AD-E64D-4755-A1CC-5EA47F49B5D8</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
   </PropertyGroup>

--- a/2-WebApp-graph-user/2-3-Multi-Tenant/Startup.cs
+++ b/2-WebApp-graph-user/2-3-Multi-Tenant/Startup.cs
@@ -60,7 +60,9 @@ namespace WebApp_OpenIDConnect_DotNet
             {
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                // Handling SameSite cookie according to https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
+                options.HandleSameSiteCookieCompatibility();
             });
 
             services.AddOptions();

--- a/2-WebApp-graph-user/2-3-Multi-Tenant/WebApp-OpenIDConnect-DotNet.csproj
+++ b/2-WebApp-graph-user/2-3-Multi-Tenant/WebApp-OpenIDConnect-DotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>aspnet-WebApp_OpenIDConnect_DotNet-99C23405-82C0-4B27-8A15-F3B0744E06BE</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
     <RootNamespace>WebApp_OpenIDConnect_DotNet</RootNamespace>

--- a/2-WebApp-graph-user/2-4-Sovereign-Call-MSGraph/Startup.cs
+++ b/2-WebApp-graph-user/2-4-Sovereign-Call-MSGraph/Startup.cs
@@ -29,7 +29,9 @@ namespace WebApp_OpenIDConnect_DotNet
             {
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                // Handling SameSite cookie according to https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
+                options.HandleSameSiteCookieCompatibility();
             });
 
             services.AddOptions();

--- a/2-WebApp-graph-user/2-4-Sovereign-Call-MSGraph/WebApp-OpenIDConnect-DotNet.csproj
+++ b/2-WebApp-graph-user/2-4-Sovereign-Call-MSGraph/WebApp-OpenIDConnect-DotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>aspnet-WebApp_OpenIDConnect_DotNet-81EA87AD-E64D-4755-A1CC-5EA47F49B5D8</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
   </PropertyGroup>

--- a/3-WebApp-multi-APIs/Startup.cs
+++ b/3-WebApp-multi-APIs/Startup.cs
@@ -30,7 +30,9 @@ namespace WebApp_OpenIDConnect_DotNet
             {
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                // Handling SameSite cookie according to https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
+                options.HandleSameSiteCookieCompatibility();
             });
 
             services.AddOptions();

--- a/3-WebApp-multi-APIs/WebApp-OpenIDConnect-DotNet.csproj
+++ b/3-WebApp-multi-APIs/WebApp-OpenIDConnect-DotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>aspnet-WebApp_OpenIDConnect_DotNet-81EA87AD-E64D-4755-A1CC-5EA47F49B5D8</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
   </PropertyGroup>

--- a/4-WebApp-your-API/Client/Startup.cs
+++ b/4-WebApp-your-API/Client/Startup.cs
@@ -31,7 +31,9 @@ namespace WebApp_OpenIDConnect_DotNet
             {
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                // Handling SameSite cookie according to https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
+                options.HandleSameSiteCookieCompatibility();
             });
 
             services.AddOptions();

--- a/4-WebApp-your-API/Client/TodoListClient.csproj
+++ b/4-WebApp-your-API/Client/TodoListClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>aspnet-WebApp_OpenIDConnect_DotNet-81EA87AD-E64D-4755-A1CC-5EA47F49B5D8</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
   </PropertyGroup>

--- a/4-WebApp-your-API/TodoListService/TodoListService.csproj
+++ b/4-WebApp-your-API/TodoListService/TodoListService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>aspnet-TodoListService-03230DB1-5145-408C-A48B-BE3DAFC56C30</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
   </PropertyGroup>

--- a/5-WebApp-AuthZ/5-1-Roles/Startup.cs
+++ b/5-WebApp-AuthZ/5-1-Roles/Startup.cs
@@ -33,7 +33,9 @@ namespace WebApp_OpenIDConnect_DotNet
             {
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                // Handling SameSite cookie according to https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
+                options.HandleSameSiteCookieCompatibility();
             });
 
             services.AddOptions();

--- a/5-WebApp-AuthZ/5-1-Roles/WebApp-OpenIDConnect-DotNet.csproj
+++ b/5-WebApp-AuthZ/5-1-Roles/WebApp-OpenIDConnect-DotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>aspnet-WebApp_OpenIDConnect_DotNet-81EA87AD-E64D-4755-A1CC-5EA47F49B5D8</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
   </PropertyGroup>

--- a/5-WebApp-AuthZ/5-2-Groups/Startup.cs
+++ b/5-WebApp-AuthZ/5-2-Groups/Startup.cs
@@ -30,7 +30,9 @@ namespace WebApp_OpenIDConnect_DotNet
             {
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                // Handling SameSite cookie according to https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
+                options.HandleSameSiteCookieCompatibility();
             });
 
             // Sign-in users with the Microsoft identity platform

--- a/5-WebApp-AuthZ/5-2-Groups/WebApp-OpenIDConnect-DotNet.csproj
+++ b/5-WebApp-AuthZ/5-2-Groups/WebApp-OpenIDConnect-DotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>aspnet-WebApp_OpenIDConnect_DotNet-81EA87AD-E64D-4755-A1CC-5EA47F49B5D8</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
   </PropertyGroup>

--- a/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj
+++ b/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
+++ b/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
@@ -39,7 +39,7 @@
 
   
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   

--- a/Microsoft.Identity.Web/WebAppServiceCollectionExtensions.cs
+++ b/Microsoft.Identity.Web/WebAppServiceCollectionExtensions.cs
@@ -163,11 +163,24 @@ namespace Microsoft.Identity.Web
             return services;
         }
 
+        /// <summary>
+        /// Handles SameSite cookie issue according to the https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1.
+        /// The default list of user-agents that disallow SameSite None, was taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns></returns>
         public static CookiePolicyOptions HandleSameSiteCookieCompatibility(this CookiePolicyOptions options)
         {
             return HandleSameSiteCookieCompatibility(options, DisallowsSameSiteNone);
         }
 
+        /// <summary>
+        /// Handles SameSite cookie issue according to the docs: https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
+        /// The default list of user-agents that disallow SameSite None, was taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="disallowsSameSiteNone">If you dont want to use the default user-agent list implementation, the method sent in this parameter will be run against the user-agent and if returned true, SameSite value will be set to Unspecified. The default user-agent list used can be found at: https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/</param>
+        /// <returns></returns>
         public static CookiePolicyOptions HandleSameSiteCookieCompatibility(this CookiePolicyOptions options, Func<string, bool> disallowsSameSiteNone)
         {
             options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
@@ -190,6 +203,7 @@ namespace Microsoft.Identity.Web
             }
         }
 
+        // Method taken from https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
         public static bool DisallowsSameSiteNone(string userAgent)
         {
             // Cover all iOS based browsers here. This includes:

--- a/Microsoft.Identity.Web/WebAppServiceCollectionExtensions.cs
+++ b/Microsoft.Identity.Web/WebAppServiceCollectionExtensions.cs
@@ -4,12 +4,15 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.AzureAD.UI;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Web.Resource;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -100,6 +103,7 @@ namespace Microsoft.Identity.Web
                     OpenIdConnectMiddlewareDiagnostics.Subscribe(options.Events);
                 }
             });
+
             return services;
         }
 
@@ -157,6 +161,71 @@ namespace Microsoft.Identity.Web
                 };
             });
             return services;
+        }
+
+        public static CookiePolicyOptions HandleSameSiteCookieCompatibility(this CookiePolicyOptions options)
+        {
+            return HandleSameSiteCookieCompatibility(options, DisallowsSameSiteNone);
+        }
+
+        public static CookiePolicyOptions HandleSameSiteCookieCompatibility(this CookiePolicyOptions options, Func<string, bool> disallowsSameSiteNone)
+        {
+            options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+            options.OnAppendCookie = cookieContext =>
+                CheckSameSite(cookieContext.Context, cookieContext.CookieOptions, disallowsSameSiteNone);
+            options.OnDeleteCookie = cookieContext =>
+                CheckSameSite(cookieContext.Context, cookieContext.CookieOptions, disallowsSameSiteNone);
+            return options;
+        }
+
+        private static void CheckSameSite(HttpContext httpContext, CookieOptions options, Func<string, bool> disallowsSameSiteNone)
+        {
+            if (options.SameSite == SameSiteMode.None)
+            {
+                var userAgent = httpContext.Request.Headers["User-Agent"].ToString();
+                if (disallowsSameSiteNone(userAgent))
+                {
+                    options.SameSite = SameSiteMode.Unspecified;
+                }
+            }
+        }
+
+        public static bool DisallowsSameSiteNone(string userAgent)
+        {
+            // Cover all iOS based browsers here. This includes:
+            // - Safari on iOS 12 for iPhone, iPod Touch, iPad
+            // - WkWebview on iOS 12 for iPhone, iPod Touch, iPad
+            // - Chrome on iOS 12 for iPhone, iPod Touch, iPad
+            // All of which are broken by SameSite=None, because they use the iOS networking
+            // stack.
+            if (userAgent.Contains("CPU iPhone OS 12") ||
+                userAgent.Contains("iPad; CPU OS 12"))
+            {
+                return true;
+            }
+
+            // Cover Mac OS X based browsers that use the Mac OS networking stack. 
+            // This includes:
+            // - Safari on Mac OS X.
+            // This does not include:
+            // - Chrome on Mac OS X
+            // Because they do not use the Mac OS networking stack.
+            if (userAgent.Contains("Macintosh; Intel Mac OS X 10_14") &&
+                userAgent.Contains("Version/") && userAgent.Contains("Safari"))
+            {
+                return true;
+            }
+
+            // Cover Chrome 50-69, because some versions are broken by SameSite=None, 
+            // and none in this range require it.
+            // Note: this covers some pre-Chromium Edge versions, 
+            // but pre-Chromium Edge does not require SameSite=None.
+            if (userAgent.Contains("Chrome/5") || userAgent.Contains("Chrome/6"))
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Purpose
In order to work with the "sameSite = none" compatibility problem, a method was added on Microsoft.Identity.Web using the logic suggested in [this Microsoft doc](https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1). 

I am opening this PR to get a feedback of the implementation used. If in agreement, I will apply the changes in all samples 

### What was done?
- Updated to Core 3.1, so we can support the new `SameSiteMode.Unspecified` value (Core 3.0 workaround didnt work and a [Github issue has been opened](https://github.com/dotnet/aspnetcore/issues/18362))
- Created a static method `HandleSameSiteCookieCompatibility` (name is opened for suggestions) that injects the MS Doc suggested code in the `CookiePolicyOptions`
- Added an option to extend the "check user-agent against list" so developers are free to pass their own implementation as parameter. 
- The default "check user-agent against list" method was extracted from MS Docs 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
