### PR TITLE
Handle tailing slashes in configured Authority and Instance

### DIFF
--- a/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
+++ b/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Build Tools" Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   
@@ -53,9 +53,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.1" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.8.1" />
   </ItemGroup>
 </Project>

--- a/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -264,6 +264,9 @@ namespace Microsoft.Identity.Web
                 request.PathBase,
                 azureAdOptions.CallbackPath ?? string.Empty);
 
+            if (!applicationOptions.Instance.EndsWith("/"))
+                applicationOptions.Instance += "/";
+
             string authority = $"{applicationOptions.Instance}{applicationOptions.TenantId}/";
 
             var app = ConfidentialClientApplicationBuilder

--- a/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
+++ b/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
@@ -58,11 +58,12 @@ namespace Microsoft.Identity.Web
                     authority += "/v2.0";
                 options.Authority = authority;
 
-                // The valid audiences are both the Client ID (options.Audience) and api://{ClientID}
-                options.TokenValidationParameters.ValidAudiences = new string[]
-                {
-                    options.Audience, $"api://{options.Audience}"
-                };
+                // The valid audience could be given as Client Id or as Uri. If it does not start with 'api://', this variant is added to the list of valid audiences.
+                var validAudiences = new List<string> { options.Audience };
+                if (!options.Audience.StartsWith("api://", StringComparison.OrdinalIgnoreCase))
+                    validAudiences.Add($"api://{options.Audience}");
+
+                options.TokenValidationParameters.ValidAudiences = validAudiences;
 
                 // Instead of using the default validation (validating against a single tenant, as we do in line of business apps),
                 // we inject our own multi-tenant validation logic (which even accepts both v1.0 and v2.0 tokens)

--- a/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
+++ b/Microsoft.Identity.Web/WebApiServiceCollectionExtensions.cs
@@ -53,7 +53,10 @@ namespace Microsoft.Identity.Web
                 configuration.Bind(configSectionName, options);
 
                 // This is an Microsoft identity platform Web API
-                options.Authority += "/v2.0";
+                var authority = options.Authority.Trim().TrimEnd('/');
+                if (!authority.EndsWith("v2.0"))
+                    authority += "/v2.0";
+                options.Authority = authority;
 
                 // The valid audiences are both the Client ID (options.Audience) and api://{ClientID}
                 options.TokenValidationParameters.ValidAudiences = new string[]


### PR DESCRIPTION
## Purpose
```
Allow configuration of Instance and Authority with or without tailing slash.
Distinguish valid audiences as specified by Client Id or by Audience Uri - don't prefix prefix audience with api:// if already prefixed.
```

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe:
Input tolerance.
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```

```

## What to Check
Verify that the following are valid
* Try configuration strings for Authority and Instance that ends with or without slash.
* Try configuring the Audience using Client Id or Audience Uri (either prefixed by 'api://' or not).

## Other Information
<!-- Add any other helpful information that may be needed here. -->