### PR TITLE
Test and fix B2C web app calls web api scenario [WIP]

### DIFF
--- a/4-WebApp-your-API/Client/Program.cs
+++ b/4-WebApp-your-API/Client/Program.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Hosting;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
 namespace WebApp_OpenIDConnect_DotNet

--- a/4-WebApp-your-API/Client/Services/TodoListService.cs
+++ b/4-WebApp-your-API/Client/Services/TodoListService.cs
@@ -1,26 +1,5 @@
-﻿/*
- The MIT License (MIT)
-
-Copyright (c) 2018 Microsoft Corporation
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
- */
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
@@ -59,11 +38,11 @@ namespace TodoListClient.Services
 
         public TodoListService(ITokenAcquisition tokenAcquisition, HttpClient httpClient, IConfiguration configuration, IHttpContextAccessor contextAccessor)
         {
-            this._httpClient = httpClient;
-            this._tokenAcquisition = tokenAcquisition;
-            this._contextAccessor = contextAccessor;
-            this._TodoListScope = configuration["TodoList:TodoListScope"];
-            this._TodoListBaseAddress = configuration["TodoList:TodoListBaseAddress"];
+            _httpClient = httpClient;
+            _tokenAcquisition = tokenAcquisition;
+            _contextAccessor = contextAccessor;
+            _TodoListScope = configuration["TodoList:TodoListScope"];
+            _TodoListBaseAddress = configuration["TodoList:TodoListBaseAddress"];
         }
 
         public async Task<Todo> AddAsync(Todo todo)
@@ -73,7 +52,7 @@ namespace TodoListClient.Services
             var jsonRequest = JsonConvert.SerializeObject(todo);
             var jsoncontent = new StringContent(jsonRequest, Encoding.UTF8, "application/json");
 
-            var response = await this._httpClient.PostAsync($"{this._TodoListBaseAddress}/api/todolist", jsoncontent);
+            var response = await this._httpClient.PostAsync($"{ _TodoListBaseAddress}/api/todolist", jsoncontent);
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -90,7 +69,7 @@ namespace TodoListClient.Services
         {
             await PrepareAuthenticatedClient();
 
-            var response = await this._httpClient.DeleteAsync($"{this._TodoListBaseAddress}/api/todolist/{id}");
+            var response = await this._httpClient.DeleteAsync($"{ _TodoListBaseAddress}/api/todolist/{id}");
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -107,7 +86,7 @@ namespace TodoListClient.Services
             var jsonRequest = JsonConvert.SerializeObject(todo);
             var jsoncontent = new StringContent(jsonRequest, Encoding.UTF8, "application/json-patch+json");
 
-            var response = await this._httpClient.PatchAsync($"{this._TodoListBaseAddress}/api/todolist/{todo.Id}", jsoncontent);
+            var response = await _httpClient.PatchAsync($"{ _TodoListBaseAddress}/api/todolist/{todo.Id}", jsoncontent);
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -124,7 +103,7 @@ namespace TodoListClient.Services
         {
             await PrepareAuthenticatedClient();
 
-            var response = await this._httpClient.GetAsync($"{this._TodoListBaseAddress}/api/todolist");
+            var response = await _httpClient.GetAsync($"{ _TodoListBaseAddress}/api/todolist");
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 var content = await response.Content.ReadAsStringAsync();
@@ -137,18 +116,18 @@ namespace TodoListClient.Services
         }
 
         private async Task PrepareAuthenticatedClient()
-        {
-            var accessToken = await this._tokenAcquisition.GetAccessTokenForUserAsync(new[] { this._TodoListScope });
+         {
+            var accessToken = await _tokenAcquisition.GetAccessTokenForUserAsync(new[] { _TodoListScope });
             Debug.WriteLine($"access token-{accessToken}");
-            this._httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-            this._httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         }
 
         public async Task<Todo> GetAsync(int id)
         {
             await PrepareAuthenticatedClient();
 
-            var response = await this._httpClient.GetAsync($"{this._TodoListBaseAddress}/api/todolist/{id}");
+            var response = await _httpClient.GetAsync($"{ _TodoListBaseAddress}/api/todolist/{id}");
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 var content = await response.Content.ReadAsStringAsync();

--- a/4-WebApp-your-API/Client/Startup.cs
+++ b/4-WebApp-your-API/Client/Startup.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -7,7 +10,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
-using System.IdentityModel.Tokens.Jwt;
 using TodoListClient.Services;
 using Microsoft.Extensions.Hosting;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;

--- a/4-WebApp-your-API/Client/TodoListClient.csproj
+++ b/4-WebApp-your-API/Client/TodoListClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <UserSecretsId>aspnet-WebApp_OpenIDConnect_DotNet-81EA87AD-E64D-4755-A1CC-5EA47F49B5D8</UserSecretsId>
+    <UserSecretsId>aspnet-WebApp_OpenIDConnect_DotNet-81EA87AD-E64D-4755-A1CC-5EA47F49B5D9</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
   </PropertyGroup>
 

--- a/4-WebApp-your-API/TodoListService/Program.cs
+++ b/4-WebApp-your-API/TodoListService/Program.cs
@@ -1,26 +1,5 @@
-﻿/*
- The MIT License (MIT)
-
-Copyright (c) 2018 Microsoft Corporation
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
- */
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;

--- a/4-WebApp-your-API/TodoListService/Startup.cs
+++ b/4-WebApp-your-API/TodoListService/Startup.cs
@@ -1,26 +1,5 @@
-﻿/*
- The MIT License (MIT)
-
-Copyright (c) 2018 Microsoft Corporation
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
- */
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -28,7 +7,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Identity.Web;
-using System.IdentityModel.Tokens.Jwt;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 
 namespace TodoListService

--- a/Microsoft.Identity.Web/Base64UrlHelpers.cs
+++ b/Microsoft.Identity.Web/Base64UrlHelpers.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace Microsoft.Identity.Web
+{
+    internal static class Base64UrlHelpers
+    {
+        private const char Base64PadCharacter = '=';
+        private const char Base64Character62 = '+';
+        private const char Base64Character63 = '/';
+        private const char Base64UrlCharacter62 = '-';
+        private const char Base64UrlCharacter63 = '_';
+        private static readonly Encoding TextEncoding = Encoding.UTF8;
+
+        private static readonly string DoubleBase64PadCharacter = string.Format(CultureInfo.InvariantCulture, "{0}{0}",
+            Base64PadCharacter);
+
+        //
+        // The following functions perform base64url encoding which differs from regular base64 encoding as follows
+        // * padding is skipped so the pad character '=' doesn't have to be percent encoded
+        // * the 62nd and 63rd regular base64 encoding characters ('+' and '/') are replace with ('-' and '_')
+        // The changes make the encoding alphabet file and URL safe
+        // See RFC4648, section 5 for more info
+        //
+        public static string Encode(string arg)
+        {
+            if (arg == null)
+            {
+                return null;
+            }
+
+            return Encode(TextEncoding.GetBytes(arg));
+        }
+
+        public static string DecodeToString(string arg)
+        {
+            byte[] decoded = DecodeToBytes(arg);
+            return CreateString(decoded);
+        }
+
+        public static string CreateString(byte[] bytes)
+        {
+            return Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+        }
+
+        public static byte[] DecodeToBytes(string arg)
+        {
+            string s = arg;
+            s = s.Replace(Base64UrlCharacter62, Base64Character62); // 62nd char of encoding
+            s = s.Replace(Base64UrlCharacter63, Base64Character63); // 63rd char of encoding
+
+            switch (s.Length % 4)
+            {
+                // Pad
+                case 0:
+                    break; // No pad chars in this case
+                case 2:
+                    s += DoubleBase64PadCharacter;
+                    break; // Two pad chars
+                case 3:
+                    s += Base64PadCharacter;
+                    break; // One pad char
+                default:
+                    throw new ArgumentException("Illegal base64url string!", nameof(arg));
+            }
+
+            return Convert.FromBase64String(s); // Standard base64 decoder
+        }
+
+        internal static string Encode(byte[] arg)
+        {
+            if (arg == null)
+            {
+                return null;
+            }
+
+            string s = Convert.ToBase64String(arg);
+            s = s.Split(Base64PadCharacter)[0]; // RemoveAccount any trailing padding
+            s = s.Replace(Base64Character62, Base64UrlCharacter62); // 62nd char of encoding
+            s = s.Replace(Base64Character63, Base64UrlCharacter63); // 63rd char of encoding
+
+            return s;
+        }
+    }
+}

--- a/Microsoft.Identity.Web/ClaimConstants.cs
+++ b/Microsoft.Identity.Web/ClaimConstants.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Identity.Web
         public const string PreferredUserName = "preferred_username";
         public const string TenantId = "http://schemas.microsoft.com/identity/claims/tenantid";
         public const string Tid = "tid";
+        public const string ClientInfo = "client_info";
         // Older scope claim
         public const string Scope = "http://schemas.microsoft.com/identity/claims/scope";
         // Newer scope claim
@@ -23,6 +24,7 @@ namespace Microsoft.Identity.Web
 
         // Policy claims
         public const string Acr = "acr";
+        public const string UserFlow = "http://schemas.microsoft.com/claims/authnclassreference";
         public const string Tfp = "tfp";
     }
 }

--- a/Microsoft.Identity.Web/ClaimsPrincipalExtensions.cs
+++ b/Microsoft.Identity.Web/ClaimsPrincipalExtensions.cs
@@ -23,9 +23,11 @@ namespace Microsoft.Identity.Web
             string tenantId = claimsPrincipal.GetTenantId();
             string userFlowId = claimsPrincipal.GetUserFlowId();
 
-            if (!string.IsNullOrWhiteSpace(nameIdentifierId) && !string.IsNullOrWhiteSpace(tenantId) && !string.IsNullOrWhiteSpace(userFlowId))
+            if (!string.IsNullOrWhiteSpace(nameIdentifierId) &&
+                !string.IsNullOrWhiteSpace(tenantId) &&
+                !string.IsNullOrWhiteSpace(userFlowId))
             {
-                // B2C pattern: {oid}-{tfp}.{tid}
+                // B2C pattern: {oid}-{userFlow}.{tid}
                 return $"{nameIdentifierId}-{userFlowId}.{tenantId}";
             }
             else if (!string.IsNullOrWhiteSpace(userObjectId) && !string.IsNullOrWhiteSpace(tenantId))
@@ -64,8 +66,9 @@ namespace Microsoft.Identity.Web
             string tenantId = claimsPrincipal.FindFirstValue(ClaimConstants.Tid);
             if (string.IsNullOrEmpty(tenantId))
             {
-                tenantId = claimsPrincipal.FindFirstValue(ClaimConstants.TenantId);
+                return claimsPrincipal.FindFirstValue(ClaimConstants.TenantId);
             }
+
             return tenantId;
         }
 
@@ -125,7 +128,7 @@ namespace Microsoft.Identity.Web
             // Finally falling back to name
             return claimsPrincipal.FindFirstValue(ClaimConstants.Name);
         }
-        
+
         /// <summary>
         /// Gets the user flow id associated with the <see cref="ClaimsPrincipal"/>
         /// </summary>
@@ -134,6 +137,11 @@ namespace Microsoft.Identity.Web
         public static string GetUserFlowId(this ClaimsPrincipal claimsPrincipal)
         {
             string userFlowId = claimsPrincipal.FindFirstValue(ClaimConstants.Tfp);
+            if (string.IsNullOrEmpty(userFlowId))
+            {
+                return claimsPrincipal.FindFirstValue(ClaimConstants.UserFlow);
+            }
+
             return userFlowId;
         }
 

--- a/Microsoft.Identity.Web/ClientInfo.cs
+++ b/Microsoft.Identity.Web/ClientInfo.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Microsoft.Identity.Web
+{
+    [DataContract]
+    internal class ClientInfo
+    {
+        [DataMember(Name = "uid", IsRequired = false)]
+        public string UniqueObjectIdentifier { get; set; }
+
+        [DataMember(Name = "utid", IsRequired = false)]
+        public string UniqueTenantIdentifier { get; set; }
+
+        public static ClientInfo CreateFromJson(string clientInfo)
+        {
+            if (string.IsNullOrEmpty(clientInfo))
+            {
+                throw new ArgumentNullException(nameof(clientInfo), $"client info returned from the server is null");
+            }
+
+            try
+            {
+                return DeserializeFromJson<ClientInfo>(Base64UrlHelpers.DecodeToBytes(clientInfo));
+            }
+            catch (Exception exc)
+            {
+                throw new ArgumentException($"Failed to parse the returned client info. ", nameof(clientInfo));
+            }
+        }
+
+        internal static T DeserializeFromJson<T>(byte[] jsonByteArray)
+        {
+            if (jsonByteArray == null || jsonByteArray.Length == 0)
+            {
+                return default;
+            }
+
+            using (var stream = new MemoryStream(jsonByteArray))
+            using (var reader = new StreamReader(stream, Encoding.UTF8))
+                return (T)JsonSerializer.Create().Deserialize(reader, typeof(T));
+        }
+    }
+}

--- a/Microsoft.Identity.Web/Resource/AadIssuerValidator.cs
+++ b/Microsoft.Identity.Web/Resource/AadIssuerValidator.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Identity.Web.Resource
         /// <exception cref="SecurityTokenInvalidIssuerException">if the issuer </exception>
         public string Validate(string actualIssuer, SecurityToken securityToken, TokenValidationParameters validationParameters)
         {
-            if (String.IsNullOrEmpty(actualIssuer))
+            if (string.IsNullOrEmpty(actualIssuer))
                 throw new ArgumentNullException(nameof(actualIssuer));
 
             if (securityToken == null)
@@ -165,21 +165,18 @@ namespace Microsoft.Identity.Web.Resource
                 if (jwtSecurityToken.Payload.TryGetValue(ClaimConstants.Tid, out object tenantId))
                     return tenantId as string;
 
-                // Since B2C doesn't have TID as default, try to get it from iss claims
-                if (jwtSecurityToken.Claims.Any(c => c.Type == ClaimConstants.Acr || c.Type == ClaimConstants.Tfp))
-                    return GetTenantIdFromIss(jwtSecurityToken.Issuer);
+                // Since B2C doesn't have TID as default, get it from issuer
+                return GetTenantIdFromIss(jwtSecurityToken.Issuer);
             }
 
-            // brentsch - todo, TryGetPayloadValue is available in 5.5.0
             if (securityToken is JsonWebToken jsonWebToken)
             {
-                var tid = jsonWebToken.GetPayloadValue<string>(ClaimConstants.Tid);
+                jsonWebToken.TryGetPayloadValue(ClaimConstants.Tid, out string tid);
                 if (tid != null)
                     return tid;
 
-                // Since B2C doesnt have TID as default, try to get it from iss claims
-                if (jsonWebToken.Claims.Any(c => c.Type == ClaimConstants.Acr || c.Type == ClaimConstants.Tfp))
-                    return GetTenantIdFromIss(jsonWebToken.Issuer);
+                // Since B2C doesn't have TID as default, get it from issuer
+                return GetTenantIdFromIss(jsonWebToken.Issuer);
             }
 
             return string.Empty;

--- a/Microsoft.Identity.Web/Resource/OpenIdConnectMiddlewareDiagnostics.cs
+++ b/Microsoft.Identity.Web/Resource/OpenIdConnectMiddlewareDiagnostics.cs
@@ -154,7 +154,6 @@ namespace Microsoft.Identity.Web.Resource
             Debug.WriteLine($"5. Begin {nameof(OnTokenResponseReceivedAsync)}");
             await s_onTokenResponseReceived(context).ConfigureAwait(false);
             Debug.WriteLine($"5. End - {nameof(OnTokenResponseReceivedAsync)}");
-
         }
 
         private static async Task OnTokenValidatedAsync(TokenValidatedContext context)

--- a/Microsoft.Identity.Web/TokenAcquisition.cs
+++ b/Microsoft.Identity.Web/TokenAcquisition.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Identity.Web
         };
 
         /// <summary>
-        /// This handler is executed after authorization code is received (once the user signs-in and consents) during the
+        /// This handler is executed after the authorization code is received (once the user signs-in and consents) during the
         /// <a href='https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow'>Authorization code flow grant flow</a> in a web app.
         /// It uses the code to request an access token from the Microsoft Identity platform and caches the tokens and an entry about the signed-in user's account in the MSAL's token cache.
         /// The access token (and refresh token) provided in the <see cref="AuthorizationCodeReceivedContext"/>, once added to the cache, are then used to acquire more tokens using the
@@ -94,7 +94,9 @@ namespace Microsoft.Identity.Web
         /// }
         /// </code>
         /// </example>
-        public async Task AddAccountToCacheFromAuthorizationCodeAsync(AuthorizationCodeReceivedContext context, IEnumerable<string> scopes)
+        public async Task AddAccountToCacheFromAuthorizationCodeAsync(
+            AuthorizationCodeReceivedContext context,
+            IEnumerable<string> scopes)
         {
             if (context == null)
             {
@@ -129,7 +131,6 @@ namespace Microsoft.Identity.Web
                     .AcquireTokenByAuthorizationCode(scopes.Except(_scopesRequestedByMsal), context.ProtocolMessage.Code)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
-
                 context.HandleCodeRedemption(null, result.IdToken);
             }
             catch (MsalException ex)
@@ -245,10 +246,10 @@ namespace Microsoft.Identity.Web
         {
             ClaimsPrincipal user = context.HttpContext.User;
             IConfidentialClientApplication app = GetOrBuildConfidentialClientApplication();
-            IAccount account = null; 
-            
+            IAccount account = null;
+
             // For B2C, we should remove all accounts of the user regardless the user flow
-            if(_microsoftIdentityOptions.IsB2C)
+            if (_microsoftIdentityOptions.IsB2C)
             {
                 var b2cAccounts = await app.GetAccountsAsync().ConfigureAwait(false);
 
@@ -332,8 +333,6 @@ namespace Microsoft.Identity.Web
                     .Build();
             }
 
-            
-
             // Initialize token cache providers
             _tokenCacheProvider?.InitializeAsync(app.AppTokenCache);
             _tokenCacheProvider?.InitializeAsync(app.UserTokenCache);
@@ -376,7 +375,7 @@ namespace Microsoft.Identity.Web
                 }
             }
 
-            // If is B2C and could not get an account (most likely because there is no tid claims), try to get it by user flow
+            // If it is B2C and could not get an account (most likely because there is no tid claims), try to get it by user flow
             if (_microsoftIdentityOptions.IsB2C && account == null)
             {
                 string currentUserFlow = claimsPrincipal.GetUserFlowId();
@@ -406,39 +405,41 @@ namespace Microsoft.Identity.Web
             }
 
             AuthenticationResult result;
-            if (string.IsNullOrWhiteSpace(tenant))
+            // Acquire an access token as a B2C authority
+            if (_microsoftIdentityOptions.IsB2C)
             {
+                string authority = application.Authority.Replace(
+                    new Uri(application.Authority).PathAndQuery,
+                    $"/tfp/{_microsoftIdentityOptions.Domain}/{_microsoftIdentityOptions.DefaultUserFlow}");
+
                 result = await application
                     .AcquireTokenSilent(scopes.Except(_scopesRequestedByMsal), account)
+                    .WithB2CAuthority(authority)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
+
+                return result.AccessToken;
+            }
+
+            else if (!string.IsNullOrWhiteSpace(tenant))
+            {
+                // Acquire an access token as another AAD authority
+                string authority = application.Authority.Replace(new Uri(application.Authority).PathAndQuery, $"/{tenant}/");
+                result = await application
+                    .AcquireTokenSilent(scopes.Except(_scopesRequestedByMsal), account)
+                    .WithAuthority(authority)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+                return result.AccessToken;
             }
             else
             {
-                // Acquire an access token as another B2C authority
-                if (_microsoftIdentityOptions.IsB2C)
-                {
-                    string authority = application.Authority.Replace(new Uri(application.Authority).PathAndQuery, $"/tfp/{tenant}/{_microsoftIdentityOptions.DefaultUserFlow}");
-                    result = await application
-                        .AcquireTokenSilent(scopes.Except(_scopesRequestedByMsal), account)
-                        .WithB2CAuthority(authority)
-                        .ExecuteAsync()
-                        .ConfigureAwait(false);
-                }
-
-                // Acquire an access token as another AAD authority
-                else
-                {
-                    string authority = application.Authority.Replace(new Uri(application.Authority).PathAndQuery, $"/{tenant}/");
-                    result = await application
-                        .AcquireTokenSilent(scopes.Except(_scopesRequestedByMsal), account)
-                        .WithAuthority(authority)
-                        .ExecuteAsync()
-                        .ConfigureAwait(false);
-                }
+                result = await application
+                   .AcquireTokenSilent(scopes.Except(_scopesRequestedByMsal), account)
+                   .ExecuteAsync()
+                   .ConfigureAwait(false);
+                return result.AccessToken;
             }
-
-            return result.AccessToken;
         }
 
         /// <summary>

--- a/Microsoft.Identity.Web/WebAppServiceCollectionExtensions.cs
+++ b/Microsoft.Identity.Web/WebAppServiceCollectionExtensions.cs
@@ -14,6 +14,8 @@ using Microsoft.Identity.Web.Resource;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Web
@@ -76,7 +78,7 @@ namespace Microsoft.Identity.Web
             services.Configure<OpenIdConnectOptions>(openIdConnectScheme, options =>
             {
                 // Response type
-                //options.ResponseType = OpenIdConnectResponseType.CodeIdToken;
+                options.ResponseType = OpenIdConnectResponseType.CodeIdToken;
 
                 // This scope is needed to get a refresh token when users sign-in with their Microsoft personal accounts
                 // It's required by MSAL.NET and automatically provided when users sign-in with work or school accounts
@@ -100,6 +102,32 @@ namespace Microsoft.Identity.Web
                     var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>();
                     await tokenAcquisition.AddAccountToCacheFromAuthorizationCodeAsync(context, options.Scope).ConfigureAwait(false);
                     await codeReceivedHandler(context).ConfigureAwait(false);
+                };
+
+                // Handling the token validated to get the client_info for cases where tenantId is not present (example: B2C)
+                var onTokenValidatedHandler = options.Events.OnTokenValidated;
+                options.Events.OnTokenValidated = async context =>
+                {
+                    if (!context.Principal.HasClaim(c => c.Type == ClaimConstants.Tid || c.Type == ClaimConstants.TenantId))
+                    {
+                        ClientInfo clientInfoFromServer;
+                        if (context.Request.Form.ContainsKey(ClaimConstants.ClientInfo))
+                        {
+                            context.Request.Form.TryGetValue(ClaimConstants.ClientInfo, out Microsoft.Extensions.Primitives.StringValues value);
+
+                            if (!string.IsNullOrEmpty(value))
+                            {
+                                clientInfoFromServer = ClientInfo.CreateFromJson(value);
+
+                                if (clientInfoFromServer != null)
+                                {
+                                    context.Principal.Identities.FirstOrDefault().AddClaim(new Claim(ClaimConstants.Tid, clientInfoFromServer.UniqueTenantIdentifier));
+                                }
+                            }
+                        }
+                    }                   
+
+                    await onTokenValidatedHandler(context).ConfigureAwait(false);
                 };
 
                 // Handling the sign-out: removing the account from MSAL.NET cache
@@ -248,6 +276,7 @@ namespace Microsoft.Identity.Web
 
                     if (microsoftIdentityOptions.IsB2C)
                     {
+                        context.ProtocolMessage.SetParameter("client_info", "1");
                         // When a new Challenge is returned using any B2C user flow different than susi, we must change
                         // the ProtocolMessage.IssuerAddress to the desired user flow otherwise the redirect would use the susi user flow
                         await b2COidcHandlers.OnRedirectToIdentityProvider(context);


### PR DESCRIPTION
- Fix issue in AadIssuerValidator when certains claims are not present (ex. policy) in the token
- Fix bug w/scopes and scopeKeySection
- Send "client_info=1" to request to get client info back from AAD B2C
- Add ClientInfo class + methods to pull out the TenantId from the ClientInfo
- Add full value to UserFlow as it was not picking up on short version
- In TokenAcquisition, check first for b2c and then do null tenant and then tenant specific, was using the wrong authority for b2c previously
- Fix bug in determining audience validation

@jmprieur i've tested manually, but need to add unit tests. Not sure how much time i'll have for this this week, as i have some customer escalations. 