### PR TITLE
Replaced roles claim type

### DIFF
--- a/Microsoft.Identity.Web/ClaimConstants.cs
+++ b/Microsoft.Identity.Web/ClaimConstants.cs
@@ -18,6 +18,6 @@ namespace Microsoft.Identity.Web
         public const string Scope = "http://schemas.microsoft.com/identity/claims/scope";
         // Newer scope claim
         public const string Scp = "scp";
-        public const string Roles = "roles";
+        public const string Roles = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role";
     }
 }


### PR DESCRIPTION
Azure AD returns a token with the new claim type for an app registration issued for a permission of type "Application". It is the case when the API that uses `Microsoft.Identity.Web.WebApiServiceCollectionExtensions.AddProtectedWebApi` is called by a daemon app without user login (following [this documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-protected-web-api-app-registration#if-your-web-api-is-called-by-a-daemon-app)).

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Enables a web-api using `Microsoft.Identity.Web` to be called by daemon apps

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
[x] I am not sure if any other type of application uses the claim type `roles`
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
* Create a new web-api project in ASP.Net Core
* Reference `Microsoft.Identity.Web` and use `services.AddProtectedWebApi(Configuration)`
* Create an app registration for the web-api in Azure AD
* Put the Instance, TenantId, Domain and ClientId, in the appsettings.json of the web-api project:
```json
"AzureAd": {
	"Instance": "https://login.microsoftonline.com/",
	"TenantId": "VVVVVVVV-WWWW-XXXX-YYYY-ZZZZZZZZZZZZ",
	"Domain":   "[tenantName].onmicrosoft.com",
	"ClientId": "11111111-2222-3333-4444-555555555555"
}
```
* Create a console app in .Net Core
* Create an app registration for the console app in Azure AD following [this documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-protected-web-api-app-registration#if-your-web-api-is-called-by-a-daemon-app)
* In the console app, create a msal confidential client application, retrieve an authentication token and call the api with it:
```c#
var msalApp = ConfidentialClientApplicationBuilder
    .Create("[Console ClientId]")
    .WithAuthority(AzureCloudInstance.AzurePublic, "[TenantId]")
    .WithClientSecret("[Console ClientSecret]")
    .Build();
var response = await msalApp.AcquireTokenForClient(new [] { "[Web API ClientId]/.default" }).ExecuteAsync();
var token = response.AccessToken;
var client = new HttpClient
{
    BaseAddress = new Uri("https://localhost:44381")
};
client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
var result = await client.GetAsync("/weatherforecast");
var content = await result.Content.ReadAsStringAsync();
Console.WriteLine(content);
Console.ReadKey();
```

## What to Check
Verify that the following are valid
* `Microsoft.Identity.Web` should now validate the claim type in the token and no longer throw an exception. HTTP response code should be 200 instead of 500

## Other Information
<!-- Add any other helpful information that may be needed here. -->
The new claim type could be either replaced in the roles constant (as happened in this PR) or added to the allowed types in the validation in `WebApiServiceCollectionExtensions.cs:78`
```c#
// This check is required to ensure that the Web API only accepts tokens from tenants where it has been consented and provisioned.
if (!context.Principal.Claims.Any(x => x.Type == ClaimConstants.Scope)
 && !context.Principal.Claims.Any(y => y.Type == ClaimConstants.Scp)
 && !context.Principal.Claims.Any(y => y.Type == ClaimConstants.Roles))
{
    throw new UnauthorizedAccessException("Neither scope or roles claim was found in the bearer token.");
}
```