### PR TITLE
fix(client): change ports to match guide

### DIFF
--- a/4-WebApp-your-API/4-2-B2C/Client/Properties/launchSettings.json
+++ b/4-WebApp-your-API/4-2-B2C/Client/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "https://localhost:5000/",
-      "sslPort": 5000
+      "applicationUrl": "https://localhost:44321/",
+      "sslPort": 44321
     }
   },
   "profiles": {
@@ -14,7 +14,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:5000"
+      "applicationUrl": "https://localhost:44321"
     }
   }
 }


### PR DESCRIPTION
the steps to configure your app registration expect the client callback
to be listening on port 44321 instead of 5000

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* fix local configuration for b2c demo

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/tree/master/4-WebApp-your-API/4-2-B2C


* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
configure tenant details in azure b2c (including callback as described in readme)
run both projects (server and client)
```

## What to Check
Verify that the following are valid
* callback url matches port that client site is hosted at

## Other Information
<!-- Add any other helpful information that may be needed here. -->