### PR TITLE
Fixing cache purge before token expires

### DIFF
--- a/2-WebApp-graph-user/2-2-TokenCache/README.md
+++ b/2-WebApp-graph-user/2-2-TokenCache/README.md
@@ -198,6 +198,12 @@ public void ConfigureServices(IServiceCollection services)
         options.ConnectionString = Configuration.GetConnectionString("TokenCacheDbConnStr");
         options.SchemaName = "dbo";
         options.TableName = "TokenCache";
+
+       // You don't want the SQL token cache to be purged before the access token has expired. Usually
+       // access tokens expire after 1 hours (but this can be changed by token lifetime policies), whereas
+       // the default sliding expiration for the distributed SQL database is 20 mins. 
+       // Use a value which is above 60 mins (or the lifetime of a token in case of longer lived tokens)
+       options.DefaultSlidingExpiration = TimeSpan.FromMinutes(90); 
     });
 ```
 

--- a/2-WebApp-graph-user/2-2-TokenCache/README.md
+++ b/2-WebApp-graph-user/2-2-TokenCache/README.md
@@ -200,7 +200,7 @@ public void ConfigureServices(IServiceCollection services)
         options.TableName = "TokenCache";
 
        // You don't want the SQL token cache to be purged before the access token has expired. Usually
-       // access tokens expire after 1 hours (but this can be changed by token lifetime policies), whereas
+       // access tokens expire after 1 hour (but this can be changed by token lifetime policies), whereas
        // the default sliding expiration for the distributed SQL database is 20 mins. 
        // Use a value which is above 60 mins (or the lifetime of a token in case of longer lived tokens)
        options.DefaultSlidingExpiration = TimeSpan.FromMinutes(90); 

--- a/2-WebApp-graph-user/2-2-TokenCache/Startup.cs
+++ b/2-WebApp-graph-user/2-2-TokenCache/Startup.cs
@@ -58,7 +58,9 @@ namespace _2_1_Call_MSGraph
                 options.TableName = "TokenCache";
 
                 // You don't want the SQL token cache to be purged before the access token has expired. Usually
-                // access tokens expire after 1 hours (but this can be changed by token lifetime policies)
+                // access tokens expire after 1 hours (but this can be changed by token lifetime policies), whereas
+                // the default sliding expiration for the distributed SQL database is 20 mins. 
+                // Use a value which is above 60 mins (or the lifetime of a token in case of longer lived tokens)
                 options.DefaultSlidingExpiration = TimeSpan.FromMinutes(90);
             });
 

--- a/2-WebApp-graph-user/2-2-TokenCache/Startup.cs
+++ b/2-WebApp-graph-user/2-2-TokenCache/Startup.cs
@@ -58,7 +58,8 @@ namespace _2_1_Call_MSGraph
                 options.TableName = "TokenCache";
 
                 // You don't want the SQL token cache to be purged before the access token has expired. Usually
-                // access tokens expire after 1 hours (but this can be changed by token lifetime policies), whereas
+                // access tokens expire after 1 hour (but this can be changed by token lifetime policies), whereas
+
                 // the default sliding expiration for the distributed SQL database is 20 mins. 
                 // Use a value which is above 60 mins (or the lifetime of a token in case of longer lived tokens)
                 options.DefaultSlidingExpiration = TimeSpan.FromMinutes(90);

--- a/2-WebApp-graph-user/2-2-TokenCache/Startup.cs
+++ b/2-WebApp-graph-user/2-2-TokenCache/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System.IdentityModel.Tokens.Jwt;
+using System;
 
 namespace _2_1_Call_MSGraph
 {
@@ -55,6 +56,10 @@ namespace _2_1_Call_MSGraph
                 options.ConnectionString = Configuration.GetConnectionString("TokenCacheDbConnStr");
                 options.SchemaName = "dbo";
                 options.TableName = "TokenCache";
+
+                // You don't want the SQL token cache to be purged before the access token has expired. Usually
+                // access tokens expire after 1 hours (but this can be changed by token lifetime policies)
+                options.DefaultSlidingExpiration = TimeSpan.FromMinutes(90);
             });
 
             services.AddControllersWithViews(options =>


### PR DESCRIPTION
## Purpose
The serialized token cache should not be purged before the access token expires (otherwise the user will have to re-sign-in in a web app). However the SQL sliding expiry is 20 mins by default, whereas the token usually expire after 1h

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
Run the the sample 

## Other Information
See also https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/issues/115#issuecomment-768770898