### PR TITLE
Fix the incremental consent in 3-WebApp-multi-APIs blob

### DIFF
--- a/3-WebApp-multi-APIs/Controllers/HomeController.cs
+++ b/3-WebApp-multi-APIs/Controllers/HomeController.cs
@@ -88,6 +88,10 @@ namespace WebApp_OpenIDConnect_DotNet.Controllers
                     await blobClient.UploadAsync(stream);
                     message = "Blob successfully created";
                 }
+	        catch (MicrosoftIdentityWebChallengeUserException ex)
+                {
+                    throw ex;
+                }	
                 catch (MsalUiRequiredException ex)
                 {
                     throw ex;


### PR DESCRIPTION
Fixes the incremental consent in 3-WebApp-multi-APIs blob
The exception thrown by MIcrosoft.Identity.Web wasn't re-thrown, which prevented the incremental consent to happening
