### PR TITLE
Added new configuration keys

### DIFF
--- a/4-WebApp-your-API/4-1-MyOrg/AppCreationScripts-withCert/sample.json
+++ b/4-WebApp-your-API/4-1-MyOrg/AppCreationScripts-withCert/sample.json
@@ -28,9 +28,13 @@
   },
 
   "ReadmeSetup": {
-    "FreeText": "\n For command line run the next commands:\n",
+    "FreeText": "",
+    "IncludeFilePath": "",
     "UseNewSetup": "1", /* when set to 0, only legacy setup will be used */
-    "CertificateOption": "1" /* 1 when a certificate can be used instead of secret*/
+    "CertificateOption": "1", /* 1 when a certificate can be used instead of secret*/
+    "CreateProjectIncludeFilePath": "",
+    "AppRegistrationIncludeFilePath": "",
+    "RunSampleIncludeFilePath": ""
   },
 
   /* It either can be a text or link to another readme file */

--- a/4-WebApp-your-API/4-1-MyOrg/AppCreationScripts/Configure.ps1
+++ b/4-WebApp-your-API/4-1-MyOrg/AppCreationScripts/Configure.ps1
@@ -265,7 +265,7 @@ Function ConfigureApplications
                                                         } `
                                                        -SignInAudience AzureADMyOrg `
                                                       #end of command
-    #add password to the application
+    #add a secret to the application
     $pwdCredential = Add-MgApplicationPassword -ApplicationId $clientAadApplication.Id -PasswordCredential $key
     $clientAppKey = $pwdCredential.SecretText
     $tenantName = (Get-MgApplication -ApplicationId $clientAadApplication.Id).PublisherDomain

--- a/4-WebApp-your-API/4-1-MyOrg/AppCreationScripts/sample.json
+++ b/4-WebApp-your-API/4-1-MyOrg/AppCreationScripts/sample.json
@@ -28,9 +28,13 @@
   },
 
   "ReadmeSetup": {
-    "FreeText": "\n For command line run the next commands:\n",
+    "FreeText": "",
+    "IncludeFilePath": "",
     "UseNewSetup": "1", /* when set to 0, only legacy setup will be used */
-    "CertificateOption": "1" /* 1 when a certificate can be used instead of secret*/
+    "CertificateOption": "1", /* 1 when a certificate can be used instead of secret*/
+    "CreateProjectIncludeFilePath": "",
+    "AppRegistrationIncludeFilePath": "",
+    "RunSampleIncludeFilePath": ""
   },
 
   /* It either can be a text or link to another readme file */

--- a/4-WebApp-your-API/4-1-MyOrg/README.md
+++ b/4-WebApp-your-API/4-1-MyOrg/README.md
@@ -210,9 +210,7 @@ Follow the steps below for manually register and configure your apps
 Follow [README-use-keyvault-certificate.md](README-use-keyvault-certificate.md) to know how to use this option.
 
 ### Step 4: Running the sample
-
- For command line run the next commands:
-
+ To run the samlple, run the next commands:
 ```console
     cd 4-WebApp-Your-API\4-1-MyOrg\TodoListService
     dotnet run


### PR DESCRIPTION
## Purpose
Extended ReadmeSetup section to enable assigning a separate md file to each of 3 sub-sections:
1. Create Sample
2. App registration instructions
3. Run sample

In case the keys are empty - the default generator will kick-off
