### PR TITLE
Replace the scopes in the controller with a reference to appsettings

### DIFF
--- a/2-WebApp-graph-user/2-6-BFF-Proxy/CallGraphBFF/Program.cs
+++ b/2-WebApp-graph-user/2-6-BFF-Proxy/CallGraphBFF/Program.cs
@@ -15,8 +15,8 @@ builder.Services.AddDistributedMemoryCache();
 
 // Add Microsoft.Identity.Web services to the container.
 builder.Services.AddMicrosoftIdentityWebAppAuthentication(builder.Configuration)
-    .EnableTokenAcquisitionToCallDownstreamApi(builder.Configuration.GetSection("DownstreamApi:Scopes").Value.Split(' '))
-    .AddMicrosoftGraph(builder.Configuration.GetValue<string>("DownstreamApi:BaseUrl"), builder.Configuration.GetValue<string>("DownstreamApi:Scopes"))
+    .EnableTokenAcquisitionToCallDownstreamApi(builder.Configuration.GetSection("DownstreamApi:Scopes").Value!.Split(' '))
+    .AddMicrosoftGraph(builder.Configuration.GetValue<string>("DownstreamApi:BaseUrl")!, builder.Configuration.GetValue<string>("DownstreamApi:Scopes")!)
     .AddInMemoryTokenCaches();
 
 // Add session for sharing non-sensitive strings between routes.

--- a/4-WebApp-your-API/4-1-MyOrg/Client/Controllers/TodoListController.cs
+++ b/4-WebApp-your-API/4-1-MyOrg/Client/Controllers/TodoListController.cs
@@ -9,11 +9,7 @@ using System.Collections.Generic;
 
 namespace TodoListClient.Controllers
 {
-    // TODO: Change the "c53a1bc4-9757-407d-a76a-51a2032d2afb" GUID
-    // by the Application ID of the web API
-    [AuthorizeForScopes(Scopes = new string[]{
-        "api://c53a1bc4-9757-407d-a76a-51a2032d2afb/ToDoList.Read",
-        "api://c53a1bc4-9757-407d-a76a-51a2032d2afb/ToDoList.ReadWrite"})]
+    [AuthorizeForScopes(ScopeKeySection = "TodoList:Scopes")]
     public class TodoListController : Controller
     {
         private IDownstreamApi _downstreamApi;


### PR DESCRIPTION
Avoid confusion and reduce edits needed to get the sample to run properly by referencing appsettings for the scopes from the client controller. 