### PR TITLE
fix sign-in sign-up on B2C project by adding appsetting value

### DIFF
--- a/1-WebApp-OIDC/1-5-B2C/appsettings.json
+++ b/1-WebApp-OIDC/1-5-B2C/appsettings.json
@@ -1,14 +1,15 @@
 ﻿{
-    "AzureAdB2C": {
-        "Instance": "https://fabrikamb2c.b2clogin.com",
-        "ClientId": "90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6",
-        "Domain": "fabrikamb2c.onmicrosoft.com",
-        "SignedOutCallbackPath": "/signout/B2C_1_susi",
-        "SignUpSignInPolicyId": "b2c_1_susi",
-        "ResetPasswordPolicyId": "b2c_1_reset",
-        "EditProfilePolicyId": "b2c_1_edit_profile" // Optional profile editing policy
-        //"CallbackPath": "/signin/B2C_1_sign_up_in"  // defaults to /signin-oidc
-    },
+  "AzureAdB2C": {
+    "Instance": "https://fabrikamb2c.b2clogin.com",
+    "ClientId": "90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6",
+    "Domain": "fabrikamb2c.onmicrosoft.com",
+    "Tenant": "fabrikamb2c.onmicrosoft.com",
+    "SignedOutCallbackPath": "/signout/B2C_1_susi",
+    "SignUpSignInPolicyId": "b2c_1_susi",
+    "ResetPasswordPolicyId": "b2c_1_reset",
+    "EditProfilePolicyId": "b2c_1_edit_profile" // Optional profile editing policy
+    //"CallbackPath": "/signin/B2C_1_sign_up_in"  // defaults to /signin-oidc
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
# Fixes issue #669 for the B2C project example
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/blob/master/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Issue with the B2C example with the sign-in sign-up policy. Adding a key called "Tenant" with the same value as the domain seems to fix the issue.

Fixes #669  - missing appsettings value
