### PR TITLE
Fix link in SVG

### DIFF
--- a/ReadmeFiles/aspnetcore-webapp-tutorial-alt.svg
+++ b/ReadmeFiles/aspnetcore-webapp-tutorial-alt.svg
@@ -576,7 +576,7 @@
 			</g>
 		</a>
 		<a
-				xlink:href="https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/tree/master/5-WebApp-AuthZ/5-2-Groups">
+				xlink:href="https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/tree/master/5-WebApp-AuthZ/5-1-Roles">
 			<g id="group313-173" transform="translate(363.454,-159.134) rotate(-45)" v:mID="313" v:groupContext="group"
 					v:layerMember="0">
 				<v:userDefs>

--- a/ReadmeFiles/aspnetcore-webapp-tutorial.svg
+++ b/ReadmeFiles/aspnetcore-webapp-tutorial.svg
@@ -576,7 +576,7 @@
 			</g>
 		</a>
 		<a
-				xlink:href="https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/tree/master/5-WebApp-AuthZ/5-2-Groups">
+				xlink:href="https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/tree/master/5-WebApp-AuthZ/5-1-Roles">
 			<g id="group313-173" transform="translate(363.454,-159.134) rotate(-45)" v:mID="313" v:groupContext="group"
 					v:layerMember="0">
 				<v:userDefs>


### PR DESCRIPTION
# Fix link in SVG

Summary of the changes

## Description

The clickable nodes in the SVG for "with roles" was incorrect. Both "with roles" and "with groups" lead to 5-2-groups which is incorrect. "with roles" should lead to 5-1-roles and "with groups" should lead to 5-2-groups. I have corrected the links in the svg to reflect this.

