### PR TITLE
Fix for KeyVault integration not working in net8.0

### DIFF
--- a/2-WebApp-graph-user/2-1-Call-MSGraph/README.md
+++ b/2-WebApp-graph-user/2-1-Call-MSGraph/README.md
@@ -409,7 +409,7 @@ using Azure.Security.KeyVault.Secrets;
 ```CSharp
     // uncomment the following 3 lines to get ClientSecret from KeyVault
   string tenantId = Configuration.GetValue<string>("AzureAd:TenantId");
-  services.Configure<MicrosoftIdentityOptions>(
+  services.Configure<MicrosoftIdentityOptions>(OpenIdConnectDefaults.AuthenticationScheme,
         options => { options.ClientSecret = GetSecretFromKeyVault(tenantId, "ENTER_YOUR_SECRET_NAME_HERE"); });
 ```
 
@@ -428,7 +428,7 @@ using Azure.Security.KeyVault.Secrets;
 
         // uncomment the following 3 lines to get ClientSecret from KeyVault
             string tenantId = Configuration.GetValue<string>("AzureAd:TenantId");
-            services.Configure<MicrosoftIdentityOptions>(
+            services.Configure<MicrosoftIdentityOptions>(OpenIdConnectDefaults.AuthenticationScheme,
             options => { options.ClientSecret = GetSecretFromKeyVault(tenantId, "myClientSecret"); });
 
       // ... more method code continues below

--- a/2-WebApp-graph-user/2-1-Call-MSGraph/ReadmeFiles/Deployment.md
+++ b/2-WebApp-graph-user/2-1-Call-MSGraph/ReadmeFiles/Deployment.md
@@ -140,7 +140,7 @@ using Azure.Security.KeyVault.Secrets;
 ```CSharp
     // uncomment the following 3 lines to get ClientSecret from KeyVault
   string tenantId = Configuration.GetValue<string>("AzureAd:TenantId");
-  services.Configure<MicrosoftIdentityOptions>(
+  services.Configure<MicrosoftIdentityOptions>(OpenIdConnectDefaults.AuthenticationScheme,
         options => { options.ClientSecret = GetSecretFromKeyVault(tenantId, "ENTER_YOUR_SECRET_NAME_HERE"); });
 ```
 
@@ -159,7 +159,7 @@ using Azure.Security.KeyVault.Secrets;
 
         // uncomment the following 3 lines to get ClientSecret from KeyVault
             string tenantId = Configuration.GetValue<string>("AzureAd:TenantId");
-            services.Configure<MicrosoftIdentityOptions>(
+            services.Configure<MicrosoftIdentityOptions>(OpenIdConnectDefaults.AuthenticationScheme,
             options => { options.ClientSecret = GetSecretFromKeyVault(tenantId, "myClientSecret"); });
 
       // ... more method code continues below

--- a/2-WebApp-graph-user/2-1-Call-MSGraph/Startup.cs
+++ b/2-WebApp-graph-user/2-1-Call-MSGraph/Startup.cs
@@ -37,7 +37,7 @@ namespace WebApp_OpenIDConnect_DotNet_graph
 
             // uncomment the following 3 lines to get ClientSecret from KeyVault
             //string tenantId = Configuration.GetValue<string>("AzureAd:TenantId");
-            //services.Configure<MicrosoftIdentityOptions>(
+            //services.Configure<MicrosoftIdentityOptions>(OpenIdConnectDefaults.AuthenticationScheme,
             //   options => { options.ClientSecret = GetSecretFromKeyVault(tenantId, "ENTER_YOUR_SECRET_NAME_HERE"); });
 
             services.AddControllersWithViews(options =>


### PR DESCRIPTION
# Fix for KeyVault integration not working in net8.0

Fixes an issue where pulling the client secret from Key Vault did not work under net8.0

## Description

Adding OpenIdConnectDefaults.AuthenticationScheme as parameter to services.Configure() fixes the issue.


